### PR TITLE
Eh 454 caller id tuki

### DIFF
--- a/oppija/src/config.ts
+++ b/oppija/src/config.ts
@@ -26,3 +26,4 @@ const backendUrl = config.backendUrl
 
 export const apiUrl = (path: string) => `${backendUrl}/${path}`
 export const apiPrefix = "oppija"
+export const callerId = "1.2.246.562.10.00000000001.ehoks.ehoks-ui.oppija"

--- a/oppija/src/config.ts
+++ b/oppija/src/config.ts
@@ -26,4 +26,12 @@ const backendUrl = config.backendUrl
 
 export const apiUrl = (path: string) => `${backendUrl}/${path}`
 export const apiPrefix = "oppija"
-export const callerId = "1.2.246.562.10.00000000001.ehoks.ehoks-ui.oppija"
+export const callerId = (headers?: Headers) =>
+  headers
+    ? headers.append(
+        "Caller-Id",
+        "1.2.246.562.10.00000000001.ehoks.ehoks-ui.oppija"
+      )
+    : new Headers({
+        "Caller-Id": "1.2.246.562.10.00000000001.ehoks.ehoks-ui.oppija"
+      })

--- a/oppija/src/index.tsx
+++ b/oppija/src/index.tsx
@@ -17,7 +17,10 @@ import { RootStore } from "./stores/RootStore"
 addLocaleData([...fi, ...sv])
 
 // pass fetch utils to RootStore using MST's environment context, so we can easily mock it in tests
-const store = RootStore.create({}, createEnvironment(fetch, apiUrl, apiPrefix, callerId))
+const store = RootStore.create(
+  {},
+  createEnvironment(fetch, apiUrl, apiPrefix, callerId)
+)
 store.environment.getEnvironment()
 store.translations.fetchLocales()
 

--- a/oppija/src/index.tsx
+++ b/oppija/src/index.tsx
@@ -1,6 +1,6 @@
 import { APIConfigContext } from "components/APIConfigContext"
 import { AppContext } from "components/AppContext"
-import { apiPrefix, apiUrl } from "config"
+import { apiPrefix, apiUrl, callerId } from "config"
 import { createEnvironment } from "createEnvironment"
 import { fetch } from "fetchUtils"
 import { Provider } from "mobx-react"
@@ -17,7 +17,7 @@ import { RootStore } from "./stores/RootStore"
 addLocaleData([...fi, ...sv])
 
 // pass fetch utils to RootStore using MST's environment context, so we can easily mock it in tests
-const store = RootStore.create({}, createEnvironment(fetch, apiUrl, apiPrefix))
+const store = RootStore.create({}, createEnvironment(fetch, apiUrl, apiPrefix, callerId))
 store.environment.getEnvironment()
 store.translations.fetchLocales()
 

--- a/oppija/src/routes/__tests__/App.test.tsx
+++ b/oppija/src/routes/__tests__/App.test.tsx
@@ -14,6 +14,8 @@ import React from "react"
 import { RootStore } from "stores/RootStore"
 import { App } from "../App"
 
+const callerId = (headers?: Headers) => (headers ? headers : new Headers())
+
 function renderWithRouter(
   ui: any,
   { route = "/", history = createHistory(createMemorySource(route)) } = {}
@@ -33,7 +35,7 @@ it("App renders correctly", async () => {
   // pass fetch utils to root store using store's environment context
   const store = RootStore.create(
     {},
-    createEnvironment(mockFetch(apiUrl), apiUrl, "")
+    createEnvironment(mockFetch(apiUrl), apiUrl, "", callerId)
   )
   // fetch default translations
   await store.translations.fetchLocales()

--- a/oppija/src/stores/EducationProviderStore.ts
+++ b/oppija/src/stores/EducationProviderStore.ts
@@ -14,12 +14,13 @@ const EducationProviderModel = {
 export const EducationProviderStore = types
   .model("EducationProviderStore", EducationProviderModel)
   .actions(self => {
-    const { fetchSingle, apiUrl } = getEnv<StoreEnvironment>(self)
+    const { fetchSingle, apiUrl, callerId } = getEnv<StoreEnvironment>(self)
 
     const fetchInfo = flow(function*(): any {
       self.isLoading = true
       const response: APIResponse<IEducationProviderInfo> = yield fetchSingle(
-        apiUrl("education/info/")
+        apiUrl("education/info/"),
+        { headers: callerId() }
       )
       self.info = response.data
       self.isLoading = false

--- a/oppija/src/stores/EnvironmentStore.ts
+++ b/oppija/src/stores/EnvironmentStore.ts
@@ -20,15 +20,16 @@ const EnvironmentStoreModel = {
 export const EnvironmentStore = types
   .model("EnvironmentStore", EnvironmentStoreModel)
   .actions(self => {
-    const { apiUrl, fetchSingle, fetch, errors } = getEnv<StoreEnvironment>(
-      self
-    )
+    const { apiUrl, fetchSingle, fetch, errors, callerId } = getEnv<
+      StoreEnvironment
+    >(self)
 
     const getEnvironment = flow(function*(): any {
       self.isLoading = true
       try {
         const response: APIResponse = yield fetchSingle(
-          apiUrl("misc/environment")
+          apiUrl("misc/environment"),
+          { headers: callerId() }
         )
         const {
           eperusteetPerusteUrl,

--- a/oppija/src/stores/HOKSStore.ts
+++ b/oppija/src/stores/HOKSStore.ts
@@ -52,13 +52,14 @@ export const HOKSStore = types
   })
   .actions(self => {
     const root: IRootStore = getRoot(self)
-    const { apiUrl, fetchCollection, errors } = getEnv<StoreEnvironment>(self)
+    const { apiUrl, fetchCollection, errors, callerId } = getEnv<StoreEnvironment>(self)
 
     const haeSuunnitelmat = flow(function*(oid: string): any {
       self.isLoading = true
       try {
         const response: APIResponse = yield fetchCollection(
-          apiUrl(`oppija/oppijat/${oid}/hoks`)
+          apiUrl(`oppija/oppijat/${oid}/hoks`),
+          { headers: callerId() }
         )
         self.suunnitelmat = response.data
 

--- a/oppija/src/stores/OppilasStore.ts
+++ b/oppija/src/stores/OppilasStore.ts
@@ -11,7 +11,7 @@ const OppilasStoreModel = {
 export const OppilasStore = types
   .model("OppilasStore", OppilasStoreModel)
   .actions(self => {
-    const { apiUrl, fetchCollection, errors } = getEnv<StoreEnvironment>(self)
+    const { apiUrl, fetchCollection, errors, callerId } = getEnv<StoreEnvironment>(self)
     // tracks the most recent fetch by user
     let newestPromise = null
 
@@ -19,7 +19,8 @@ export const OppilasStore = types
       self.isLoading = true
       try {
         const fetchPromise: Promise<APIResponse> = fetchCollection(
-          apiUrl(`external/eperusteet/?nimi=${name}`)
+          apiUrl(`external/eperusteet/?nimi=${name}`),
+          { headers: callerId() }
         )
         newestPromise = fetchPromise
         const response = yield fetchPromise

--- a/oppija/src/stores/SessionStore.ts
+++ b/oppija/src/stores/SessionStore.ts
@@ -16,7 +16,7 @@ const SessionStoreModel = {
 export const SessionStore = types
   .model("SessionStore", SessionStoreModel)
   .actions(self => {
-    const { apiUrl, fetchSingle, deleteResource, errors } = getEnv<
+    const { apiUrl, fetchSingle, deleteResource, errors, callerId } = getEnv<
       StoreEnvironment
     >(self)
 
@@ -24,7 +24,8 @@ export const SessionStore = types
       self.isLoading = true
       try {
         const response: APIResponse = yield fetchSingle(
-          apiUrl("oppija/session")
+          apiUrl("oppija/session"),
+          { headers: callerId() }
         )
         self.user = response.data
       } catch (error) {
@@ -36,7 +37,8 @@ export const SessionStore = types
       if (self.user) {
         try {
           yield fetchSingle(apiUrl("oppija/session/update-user-info"), {
-            method: "POST"
+            method: "POST",
+            headers: callerId()
           })
           yield fetchUserInfo()
         } catch (error) {
@@ -50,7 +52,8 @@ export const SessionStore = types
       self.isLoading = true
       try {
         const response: APIResponse = yield fetchSingle(
-          apiUrl("oppija/session/user-info")
+          apiUrl("oppija/session/user-info"),
+          { headers: callerId() }
         )
         self.user = response.data
       } catch (error) {
@@ -63,7 +66,8 @@ export const SessionStore = types
       self.isLoading = true
       try {
         const response: APIResponse = yield fetchSingle(
-          apiUrl("oppija/session/settings")
+          apiUrl("oppija/session/settings"),
+          { headers: callerId() }
         )
         self.settings = response.data
       } catch (error) {
@@ -78,9 +82,7 @@ export const SessionStore = types
         yield fetchSingle(apiUrl("oppija/session/settings"), {
           method: "put",
           body: JSON.stringify(getSnapshot(self.settings)),
-          headers: {
-            "Content-Type": "application/json"
-          }
+          headers: callerId(new Headers({ "Content-Type": "application/json" }))
         })
       } catch (error) {
         errors.logError("SessionStore.saveSettings", error.message)
@@ -91,7 +93,7 @@ export const SessionStore = types
     const logout = flow(function*() {
       self.isLoading = true
       try {
-        yield deleteResource(apiUrl("oppija/session"))
+        yield deleteResource(apiUrl("oppija/session"), { headers: callerId() })
         self.user = null
         self.isLoading = false
         self.userDidLogout = true

--- a/oppija/src/stores/TyopaikanToimijaStore.ts
+++ b/oppija/src/stores/TyopaikanToimijaStore.ts
@@ -18,7 +18,7 @@ export const TyopaikanToimijaStore = types
       self.isLoading = true
       try {
         // TODO: replace with real API call
-        // const response = yield root.fetchCollection(apiUrl("oppijat"))
+        // const response = yield root.fetchCollection(apiUrl("oppijat"),{ headers: callerId() })
         // self.oppijat.replace(response.data)
         self.oppijat.replace(oppijat as any)
       } catch (error) {

--- a/oppija/src/stores/__tests__/SessionStore.test.ts
+++ b/oppija/src/stores/__tests__/SessionStore.test.ts
@@ -4,11 +4,13 @@ import { mockFetch } from "fetchUtils"
 import { when } from "mobx"
 import { SessionStore } from "stores/SessionStore"
 
+const callerId = (headers?: Headers) => (headers ? headers : new Headers())
+
 describe("SessionStore", () => {
   test("checkSession without login", () => {
     const store = SessionStore.create(
       {},
-      createEnvironment(mockFetch(apiUrl), apiUrl, "")
+      createEnvironment(mockFetch(apiUrl), apiUrl, "", callerId)
     )
 
     expect(store.isLoading).toBe(false)
@@ -28,7 +30,7 @@ describe("SessionStore", () => {
   test("checkSession with login", done => {
     const store = SessionStore.create(
       {},
-      createEnvironment(mockFetch(apiUrl, 1), apiUrl, "")
+      createEnvironment(mockFetch(apiUrl, 1), apiUrl, "", callerId)
     )
 
     expect(store.isLoading).toBe(false)
@@ -72,7 +74,7 @@ describe("SessionStore", () => {
           surname: "Testaaja"
         }
       },
-      createEnvironment(mockFetch(apiUrl, 2), apiUrl, "")
+      createEnvironment(mockFetch(apiUrl, 2), apiUrl, "", callerId)
     )
     expect(store.user).toEqual({
       commonName: "Teuvo",

--- a/shared/createEnvironment.ts
+++ b/shared/createEnvironment.ts
@@ -5,12 +5,14 @@ import { StoreEnvironment } from "types/StoreEnvironment"
 export function createEnvironment(
   fetchFn: WindowOrWorkerGlobalScope["fetch"],
   apiUrl: (path: string) => string,
-  apiPrefix: string
+  apiPrefix: string,
+  callerId: string
 ): StoreEnvironment {
   return {
     ...fetchUtils(fetchFn),
     errors: ErrorStore.create({}),
     apiUrl,
-    apiPrefix
+    apiPrefix,
+    callerId
   }
 }

--- a/shared/createEnvironment.ts
+++ b/shared/createEnvironment.ts
@@ -6,7 +6,7 @@ export function createEnvironment(
   fetchFn: WindowOrWorkerGlobalScope["fetch"],
   apiUrl: (path: string) => string,
   apiPrefix: string,
-  callerId: string
+  callerId: (headers?: Headers) => Headers
 ): StoreEnvironment {
   return {
     ...fetchUtils(fetchFn),

--- a/shared/stores/ShareLinkStore.ts
+++ b/shared/stores/ShareLinkStore.ts
@@ -13,7 +13,7 @@ export interface IShareLink extends Instance<typeof ShareLink> {}
 export const ShareLinkStore = types
   .model("ShareLinkStore", {})
   .actions(_self => {
-    // const { fetchCollection, errors } = getEnv<StoreEnvironment>(self)
+    // const { fetchCollection, errors, callerId } = getEnv<StoreEnvironment>(self)
 
     //const fetchLinks = flow(koodiUri: string, type: string) {
     const fetchLinks = function(koodiUri: string, type: string) {
@@ -44,7 +44,7 @@ export const ShareLinkStore = types
         }
       ]) as Promise<Instance<typeof ShareLink>[]>
       // try {
-      //   const response = yield fetchCollection(apiUrl("shareLinks"))
+      //   const response = yield fetchCollection(apiUrl("shareLinks"),{ headers: callerId() })
       //   return response.data
       // } catch (error) {
       //   errors.logError("ShareLinkStore.fetchLinks", error.message)

--- a/shared/stores/TranslationStore.ts
+++ b/shared/stores/TranslationStore.ts
@@ -44,7 +44,7 @@ const TranslationStoreModel = {
 export const TranslationStore = types
   .model("TranslationStore", TranslationStoreModel)
   .actions(self => {
-    const { apiUrl, apiPrefix, fetchCollection, errors } = getEnv<
+    const { apiUrl, apiPrefix, fetchCollection, errors, callerId } = getEnv<
       StoreEnvironment
     >(self)
 
@@ -58,7 +58,7 @@ export const TranslationStore = types
       self.translations.replace(defaultMessages as ApiTranslation[])
       try {
         const response: APIResponse = yield fetchCollection(
-          apiUrl(`${apiPrefix}/external/lokalisointi`)
+          apiUrl(`${apiPrefix}/external/lokalisointi`), { headers: callerId() }
         )
         // add custom translations from API
         self.translations.replace([

--- a/shared/stores/__tests__/TranslationStore.test.ts
+++ b/shared/stores/__tests__/TranslationStore.test.ts
@@ -6,12 +6,13 @@ import defaultMessages from "../TranslationStore/defaultMessages.json"
 import { createEnvironment } from "createEnvironment"
 
 const apiUrl = (path: string) => `/${path}`
+const callerId = (headers?: Headers) => (headers ? headers : new Headers())
 
 describe("TranslationStore", () => {
   test("fetchLocales fetches both defaultMessages and API translations", () => {
     const store = TranslationStore.create(
       {},
-      createEnvironment(mockFetch(apiUrl), apiUrl, "")
+      createEnvironment(mockFetch(apiUrl), apiUrl, "", callerId)
     )
 
     expect(store.isLoading).toBe(false)
@@ -35,7 +36,7 @@ describe("TranslationStore", () => {
   test("messages view returns translations in a format suitable for react-intl", () => {
     const store = TranslationStore.create(
       {},
-      createEnvironment(mockFetch(apiUrl), apiUrl, "")
+      createEnvironment(mockFetch(apiUrl), apiUrl, "", callerId)
     )
 
     store.fetchLocales()

--- a/shared/types/StoreEnvironment.ts
+++ b/shared/types/StoreEnvironment.ts
@@ -5,5 +5,5 @@ export type StoreEnvironment = ReturnType<typeof fetchUtils> & {
   errors: IErrorStore
   apiUrl: (path: string) => string
   apiPrefix: string
-  callerId: string
+  callerId: (headers?: Headers) => Headers
 }

--- a/shared/types/StoreEnvironment.ts
+++ b/shared/types/StoreEnvironment.ts
@@ -5,4 +5,5 @@ export type StoreEnvironment = ReturnType<typeof fetchUtils> & {
   errors: IErrorStore
   apiUrl: (path: string) => string
   apiPrefix: string
+  callerId: string
 }

--- a/virkailija/src/config.ts
+++ b/virkailija/src/config.ts
@@ -1,5 +1,5 @@
 const defaultConfig = () => ({
-    backendUrl: `/ehoks-virkailija-backend/api/v1`
+  backendUrl: `/ehoks-virkailija-backend/api/v1`
 })
 
 const config = (() => {
@@ -25,5 +25,5 @@ if (/\bdebug=1\b/.test(window.location.search)) {
 const backendUrl = config.backendUrl
 
 export const apiUrl = (path: string) => `${backendUrl}/${path}`
-
 export const apiPrefix = "virkailija"
+export const callerId = "1.2.246.562.10.00000000001.ehoks.ehoks-ui.virkailija"

--- a/virkailija/src/config.ts
+++ b/virkailija/src/config.ts
@@ -26,4 +26,12 @@ const backendUrl = config.backendUrl
 
 export const apiUrl = (path: string) => `${backendUrl}/${path}`
 export const apiPrefix = "virkailija"
-export const callerId = "1.2.246.562.10.00000000001.ehoks.ehoks-ui.virkailija"
+export const callerId = (headers?: Headers) =>
+  headers
+    ? headers.append(
+        "Caller-Id",
+        "1.2.246.562.10.00000000001.ehoks.ehoks-ui.virkailija"
+      )
+    : new Headers({
+        "Caller-Id": "1.2.246.562.10.00000000001.ehoks.ehoks-ui.virkailija"
+      })

--- a/virkailija/src/index.tsx
+++ b/virkailija/src/index.tsx
@@ -1,5 +1,5 @@
 import { AppContext } from "components/AppContext"
-import { apiPrefix, apiUrl } from "config"
+import { apiPrefix, apiUrl, callerId } from "config"
 import { createEnvironment } from "createEnvironment"
 import { fetch } from "fetchUtils"
 import { Provider } from "mobx-react"
@@ -16,7 +16,7 @@ import { RootStore } from "./stores/RootStore"
 addLocaleData([...fi, ...sv])
 
 // pass fetch utils to RootStore using MST's environment context, so we can easily mock it in tests
-const store = RootStore.create({}, createEnvironment(fetch, apiUrl, apiPrefix))
+const store = RootStore.create({}, createEnvironment(fetch, apiUrl, apiPrefix, callerId))
 
 store.translations.fetchLocales()
 

--- a/virkailija/src/stores/EnvironmentStore.ts
+++ b/virkailija/src/stores/EnvironmentStore.ts
@@ -18,15 +18,16 @@ const EnvironmentStoreModel = {
 export const EnvironmentStore = types
   .model("EnvironmentStore", EnvironmentStoreModel)
   .actions(self => {
-    const { apiUrl, fetchSingle, fetch, errors } = getEnv<StoreEnvironment>(
-      self
-    )
+    const { apiUrl, fetchSingle, fetch, errors, callerId } = getEnv<
+      StoreEnvironment
+    >(self)
 
     const getEnvironment = flow(function*(): any {
       self.isLoading = true
       try {
         const response: APIResponse = yield fetchSingle(
-          apiUrl("misc/environment")
+          apiUrl("misc/environment"),
+          { headers: callerId() }
         )
         const { virkailijaLoginUrl } = response.data
         self.virkailijaLoginUrl = devBackendWithoutHost(virkailijaLoginUrl)

--- a/virkailija/src/stores/KoulutuksenJarjestajaStore.ts
+++ b/virkailija/src/stores/KoulutuksenJarjestajaStore.ts
@@ -29,21 +29,23 @@ export const Oppija = types
     henkilotiedot: types.optional(SessionUser, { commonName: "", surname: "" })
   })
   .actions(self => {
-    const { fetchCollection, fetchSingle, apiUrl } = getEnv<StoreEnvironment>(
-      self
-    )
+    const { fetchCollection, fetchSingle, apiUrl, callerId } = getEnv<
+      StoreEnvironment
+    >(self)
 
     // fetches HOKSes with basic info (root level only)
     const fetchSuunnitelmat = flow(function*(): any {
       const response: APIResponse = yield fetchCollection(
-        apiUrl(`virkailija/oppijat/${self.oid}/hoksit`)
+        apiUrl(`virkailija/oppijat/${self.oid}/hoksit`),
+        { headers: callerId() }
       )
       self.suunnitelmat = response.data
     })
 
     const fetchHenkilotiedot = flow(function*(): any {
       const response: APIResponse = yield fetchSingle(
-        apiUrl(`virkailija/oppijat/${self.oid}`)
+        apiUrl(`virkailija/oppijat/${self.oid}`),
+        { headers: callerId() }
       )
       const { oid, nimi } = response.data
       self.henkilotiedot.oid = oid
@@ -139,7 +141,7 @@ const Search = types
     }
   )
   .actions(self => {
-    const { fetchCollection, apiUrl } = getEnv<StoreEnvironment>(self)
+    const { fetchCollection, apiUrl, callerId } = getEnv<StoreEnvironment>(self)
 
     const fetchOppijat = flow(function*(): any {
       // TODO fix cross reference of stores?
@@ -172,7 +174,8 @@ const Search = types
         withQueryString(apiUrl("virkailija/oppijat"), {
           ...queryParams,
           ...textQueries
-        })
+        }),
+        { headers: callerId() }
       )
       self.results = response.data
       if (response.meta["total-count"]) {

--- a/virkailija/src/stores/SessionStore.ts
+++ b/virkailija/src/stores/SessionStore.ts
@@ -34,13 +34,17 @@ export const SessionStore = types
       fetchCollection,
       fetch,
       deleteResource,
-      errors
+      errors,
+      callerId
     } = getEnv<StoreEnvironment>(self)
 
     const login = flow(function*(url: string): any {
       self.isLoading = true
       try {
-        const response: APIResponse = yield fetch(url, { mode: "no-cors" })
+        const response: APIResponse = yield fetch(url, {
+          mode: "no-cors",
+          headers: callerId()
+        })
         self.user = response.data
       } catch (error) {
         self.error = error.message
@@ -55,7 +59,9 @@ export const SessionStore = types
         changeSelectedOrganisationOid(storedOid)
       }
       try {
-        const response = yield fetchSingle(apiUrl("virkailija/session"))
+        const response = yield fetchSingle(apiUrl("virkailija/session"), {
+          headers: callerId()
+        })
 
         self.user = response.data
         const queryParams = {
@@ -71,7 +77,8 @@ export const SessionStore = types
         const organisationsData = yield fetchCollection(
           withQueryString(apiUrl("virkailija/external/organisaatio/find"), {
             ...queryParams
-          })
+          }),
+          { headers: callerId() }
         )
         self.organisations = organisationsData.data.map((o: IOrganisation) => {
           return {
@@ -93,7 +100,9 @@ export const SessionStore = types
     const logout = flow(function*() {
       self.isLoading = true
       try {
-        yield deleteResource(apiUrl("virkailija/session"))
+        yield deleteResource(apiUrl("virkailija/session"), {
+          headers: callerId()
+        })
         self.user = null
         self.isLoading = false
         self.userDidLogout = true


### PR DESCRIPTION
Kummankin puolen configeihin on lisätty Caller-Id:n lisäävä tai olemassaoleviin headereihin sen appendaava funktio ja tämä on lisätty käyttöön jokaiseen fetchejä tekevään paikkaan.

Nimi callerId ei ole enää kauhean itsestäänselvä, kun sille voi antaa parametriksi muut headerit, joten sen tilalle voisi kehittää jonkin fiksumman.