### PR TITLE
Eh 671 localen tallennus localstorageen

### DIFF
--- a/oppija/src/routes/App.tsx
+++ b/oppija/src/routes/App.tsx
@@ -1,6 +1,6 @@
 import { Router } from "@reach/router"
 import { ThemeWrapper } from "components/ThemeWrapper"
-import { parseLocaleParam } from "localeUtils"
+import { parseLocaleParam, updateLocaleLocalStorage } from "localeUtils"
 import { inject, observer } from "mobx-react"
 import React from "react"
 import { IntlProvider } from "react-intl"
@@ -64,8 +64,9 @@ export class App extends React.Component<AppProps> {
   render() {
     const { store } = this.props
     const localeParam = parseLocaleParam(window.location.search)
-    const activeLocale = localeParam
-      ? localeParam
+    const storedLocale = updateLocaleLocalStorage(localeParam)
+    const activeLocale = storedLocale
+      ? storedLocale
       : store!.translations.activeLocale
     const translations = store!.translations.messages[activeLocale]
     const messages =

--- a/shared/localeUtils.ts
+++ b/shared/localeUtils.ts
@@ -1,12 +1,37 @@
 import queryString from "query-string"
-import { Locale } from "stores/TranslationStore"
+import {Locale} from "stores/TranslationStore"
 
 export function parseLocaleParam(search: string) {
     const lang = queryString.parse(search).lang
     if (lang === 'fi') {
+        saveLocaleToLocalStorage(Locale.FI)
         return Locale.FI
     } else if (lang === 'sv') {
+        saveLocaleToLocalStorage(Locale.SV)
         return Locale.SV
+    } else {
+        return ''
+    }
+}
+
+export function updateLocaleLocalStorage(locale: Locale | string) {
+    if (locale) {
+        saveLocaleToLocalStorage(locale)
+        return locale
+    } else {
+        return readLocaleFromLocalStorage()
+    }
+}
+
+export function saveLocaleToLocalStorage(locale: string) {
+    if (window.localStorage) {
+        localStorage.setItem('ehoks-locale', locale)
+    }
+}
+
+export function readLocaleFromLocalStorage() {
+    if (window.localStorage) {
+        return localStorage.getItem('ehoks-locale') === null ? '' : localStorage.getItem('ehoks-locale')
     } else {
         return ''
     }

--- a/shared/stores/TranslationStore.ts
+++ b/shared/stores/TranslationStore.ts
@@ -2,6 +2,7 @@ import { flow, getEnv, Instance, types } from "mobx-state-tree"
 import { StoreEnvironment } from "types/StoreEnvironment"
 import defaultMessages from "./TranslationStore/defaultMessages.json"
 import { APIResponse } from "types/APIResponse"
+import { updateLocaleLocalStorage } from "localeUtils"
 
 export interface ApiTranslation {
   key: string
@@ -49,6 +50,7 @@ export const TranslationStore = types
     >(self)
 
     const setActiveLocale = (locale: Locale) => {
+      updateLocaleLocalStorage(locale)
       self.activeLocale = locale
     }
 


### PR DESCRIPTION
Lisätty localStorage localen säilömiseen, localen päättelyn prioriteettiketju on nyt: queryparametri -> localStorage -> default. Tallennetaan locale localStorageen myös joka kerta, kun TranslationStoren setActiveLocalea kutsutaan.