### PR TITLE
Automatically show Styled Components component-names at DOM

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Frontend repository for [eHOKS project](https://confluence.csc.fi/display/OPHPAL
 
 `npm install` installs required npm dependencies for `oppija` and `virkailija`
 
+`npm start --prefix oppija` or `npm start --prefix virkailija` will run the specified subdirectory's `start`-script
+
 `npm run styleguide` launches [react-styleguidist](https://react-styleguidist.js.org/) styleguide server in [localhost:6060](http://localhost:6060/)
 
 ## Dependencies and directory structure

--- a/oppija/webpack.config.js
+++ b/oppija/webpack.config.js
@@ -2,6 +2,8 @@ var webpack = require("webpack")
 var path = require("path")
 var ForkTsCheckerWebpackPlugin = require("fork-ts-checker-webpack-plugin")
 var TsconfigPathsPlugin = require("tsconfig-paths-webpack-plugin")
+var createStyledComponentsTransformer = require('typescript-plugin-styled-components').default
+var styledComponentsTransformer = createStyledComponentsTransformer()
 
 module.exports = {
   mode: "development",
@@ -56,7 +58,8 @@ module.exports = {
             loader: "ts-loader",
             options: {
               transpileOnly: true,
-              experimentalWatchApi: true
+              experimentalWatchApi: true,
+              getCustomTransformers: () => ({ before: [styledComponentsTransformer] })
             }
           }
         ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -13521,6 +13521,12 @@
       "integrity": "sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw==",
       "dev": true
     },
+    "typescript-plugin-styled-components": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/typescript-plugin-styled-components/-/typescript-plugin-styled-components-1.4.4.tgz",
+      "integrity": "sha512-w5S5lSpzRFM+61KNNpGtlF46DuTJTyzfWM4g6ic9m189ILEoU3sgoTNHNS2MxQhXsGtQZwAlINKG+Dwy0euwUg==",
+      "dev": true
+    },
     "typescript-react-intl": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/typescript-react-intl/-/typescript-react-intl-0.3.0.tgz",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "tslint-react": "^4.2.0",
     "tslint-react-a11y": "^1.1.0",
     "typescript": "^3.7.5",
+    "typescript-plugin-styled-components": "^1.4.4",
     "typescript-react-intl": "^0.3.0",
     "url-loader": "^3.0.0",
     "webpack": "^4.41.6",

--- a/virkailija/webpack.config.js
+++ b/virkailija/webpack.config.js
@@ -2,6 +2,8 @@ var webpack = require("webpack")
 var path = require("path")
 var ForkTsCheckerWebpackPlugin = require("fork-ts-checker-webpack-plugin")
 var TsconfigPathsPlugin = require("tsconfig-paths-webpack-plugin")
+var createStyledComponentsTransformer = require('typescript-plugin-styled-components').default
+var styledComponentsTransformer = createStyledComponentsTransformer()
 
 module.exports = {
   mode: "development",
@@ -56,7 +58,8 @@ module.exports = {
             loader: "ts-loader",
             options: {
               transpileOnly: true,
-              experimentalWatchApi: true
+              experimentalWatchApi: true,
+              getCustomTransformers: () => ({ before: [styledComponentsTransformer] })
             }
           }
         ]


### PR DESCRIPTION
**Affects only development builds.**

It will include component name in hashed classNames like `<div class="sc-pcLhl kBHwAC">` and replace these `styled.div` type naming in React inspector with component names.

Original Styled Components documentation supports babel-plugin, but now it can be handled with typescript plugin also. https://styled-components.com/docs/tooling#babel-plugin