### PR TITLE
Extend RouteComponentProps from Reach/Router

### DIFF
--- a/virkailija/src/routes/KoulutuksenJarjestaja.tsx
+++ b/virkailija/src/routes/KoulutuksenJarjestaja.tsx
@@ -1,4 +1,4 @@
-import { Link } from "@reach/router"
+import { RouteComponentProps, Link } from "@reach/router"
 import { Container, PaddedContent } from "components/Container"
 import { ContentArea } from "components/ContentArea"
 import { Heading } from "components/Heading"
@@ -52,9 +52,8 @@ const Spinner = styled(LoadingSpinner)`
   right: 0px;
 `
 
-interface KoulutuksenJarjestajaProps {
+interface KoulutuksenJarjestajaProps extends RouteComponentProps {
   store?: IRootStore
-  path?: string
 }
 
 @inject("store")

--- a/virkailija/src/routes/KoulutuksenJarjestaja/Opiskelija.tsx
+++ b/virkailija/src/routes/KoulutuksenJarjestaja/Opiskelija.tsx
@@ -38,6 +38,7 @@ const TopContainer = styled("div")`
 
 export interface OpiskelijaProps {
   store?: IRootStore
+  /* From router path */
   studentId?: string
 }
 

--- a/virkailija/src/routes/LuoHOKS.tsx
+++ b/virkailija/src/routes/LuoHOKS.tsx
@@ -37,9 +37,9 @@ import "./HOKSLomake/styles.css"
 import { SuccessMessage } from "./HOKSLomake/SuccessMessage"
 import { TopToolbar } from "./HOKSLomake/TopToolbar"
 import { propertiesByStep, uiSchemaByStep } from "./LuoHOKS/uiSchema"
+import { RouteComponentProps } from "@reach/router"
 
-interface LuoHOKSProps {
-  path?: string
+interface LuoHOKSProps extends RouteComponentProps {
   store?: IRootStore
 }
 

--- a/virkailija/src/routes/MuokkaaHOKS.tsx
+++ b/virkailija/src/routes/MuokkaaHOKS.tsx
@@ -35,6 +35,7 @@ import "./HOKSLomake/styles.css"
 import { SuccessMessage } from "./HOKSLomake/SuccessMessage"
 import { TopToolbar } from "./HOKSLomake/TopToolbar"
 import { propertiesByStep, uiSchemaByStep } from "./MuokkaaHOKS/uiSchema"
+import { RouteComponentProps } from "@reach/router"
 
 const disallowedKeys = ["eid", "manuaalisyotto"]
 
@@ -47,11 +48,12 @@ function trimDisallowedKeys(formData: any) {
   }, {} as any)
 }
 
-interface MuokkaaHOKSProps {
-  path?: string
+interface MuokkaaHOKSProps extends RouteComponentProps {
   store?: IRootStore
-  oppijaOid?: string
+  /* From router path */
   hoksId?: string
+  /* From router path */
+  oppijaOid?: string
 }
 
 interface MuokkaaHOKSState {

--- a/virkailija/src/routes/Yllapito.tsx
+++ b/virkailija/src/routes/Yllapito.tsx
@@ -8,6 +8,7 @@ import React from "react"
 import { FormattedMessage, intlShape } from "react-intl"
 import { IRootStore } from "stores/RootStore"
 import styled from "styled"
+import { RouteComponentProps } from "@reach/router"
 
 export const BackgroundContainer = styled("div")`
   background: #f8f8f8;
@@ -49,9 +50,8 @@ const Header = styled(Heading)`
   padding-right: 10px;
 `
 
-interface YllapitoProps {
+interface YllapitoProps extends RouteComponentProps {
   store?: IRootStore
-  path?: string
 }
 
 interface SystemInfo {


### PR DESCRIPTION
Extend RouteComponentProps from Reach/Router to have more clear why and where these props come from. Add comments on props that are deriver from router path