### PR TITLE
New buttons for yllapito

### DIFF
--- a/virkailija/src/routes/Yllapito.tsx
+++ b/virkailija/src/routes/Yllapito.tsx
@@ -75,7 +75,7 @@ interface YllapitoState {
   message: string
   success: boolean
   systemInfo?: SystemInfo | null
-  hoksId?: number,
+  hoksId?: number
   opiskeluoikeusOid?: string | ""
 }
 
@@ -214,7 +214,6 @@ export class Yllapito extends React.Component<YllapitoProps> {
     }
   }
 
-
   onGetHoksId = async (event: any) => {
     const { intl } = this.context
     const { opiskeluoikeusOid } = this.state
@@ -254,12 +253,11 @@ export class Yllapito extends React.Component<YllapitoProps> {
     }
   }
 
-  handleOidChange(event: any) {
-    const inputOid = event.target.value
+  handleOidChange = (inputOid: any) => {
+    // const inputOid = event.target.value
     this.setState({
       opiskeluoikeusOid: inputOid
     })
-    console.log(this.state.opiskeluoikeusOid)
   }
 
   hideMessage = () => {
@@ -285,10 +283,10 @@ export class Yllapito extends React.Component<YllapitoProps> {
                   {message}
                 </SuccessMessage>
               ) : (
-                  <FailureMessage onClick={this.hideMessage}>
-                    {message}
-                  </FailureMessage>
-                )}
+                <FailureMessage onClick={this.hideMessage}>
+                  {message}
+                </FailureMessage>
+              )}
             </TopContainer>
             <ContentArea>
               {systemInfo && (
@@ -323,7 +321,7 @@ export class Yllapito extends React.Component<YllapitoProps> {
                           <input
                             type="text"
                             value={this.state.opiskeluoikeusOid}
-                            onChange={this.handleOidChange.bind(this)}
+                            onChange={e => this.handleOidChange(e.target.value)}
                           />
                         </form>
                       </ContentElement>
@@ -340,8 +338,7 @@ export class Yllapito extends React.Component<YllapitoProps> {
                       id="yllapito.hoksIdTulos"
                       defaultMessage="Hoks-id on: {hoksId}"
                       values={{
-                        hoksId:
-                          this.state.hoksId
+                        hoksId: this.state.hoksId
                       }}
                     />
                   </ContentElement>

--- a/virkailija/src/routes/Yllapito.tsx
+++ b/virkailija/src/routes/Yllapito.tsx
@@ -65,6 +65,9 @@ interface SystemInfo {
     unindexedOppijat: number
     unindexedOpiskeluoikeudet: number
   }
+  hoksit: {
+    amount: number
+  }
 }
 
 interface YllapitoState {
@@ -72,6 +75,8 @@ interface YllapitoState {
   message: string
   success: boolean
   systemInfo?: SystemInfo | null
+  hoksId?: number,
+  opiskeluoikeusOid?: string | ""
 }
 
 interface SystemInfoResponse {
@@ -89,7 +94,9 @@ export class Yllapito extends React.Component<YllapitoProps> {
     isLoading: false,
     message: "",
     success: false,
-    systemInfo: null
+    systemInfo: null,
+    hoksId: undefined,
+    opiskeluoikeusOid: ""
   }
 
   async loadSystemInfo() {
@@ -207,6 +214,54 @@ export class Yllapito extends React.Component<YllapitoProps> {
     }
   }
 
+
+  onGetHoksId = async (event: any) => {
+    const { intl } = this.context
+    const { opiskeluoikeusOid } = this.state
+    event.preventDefault()
+    const request = await window.fetch(
+      `/ehoks-virkailija-backend/api/v1/virkailija/opiskeluoikeus/${opiskeluoikeusOid}`,
+      {
+        method: "GET",
+        credentials: "include",
+        headers: {
+          Accept: "application/json; charset=utf-8",
+          "Content-Type": "application/json"
+        }
+      }
+    )
+    if (request.status === 200) {
+      const json = await request.json()
+      console.log(json)
+      this.setState({
+        success: true,
+        message: intl.formatMessage({
+          id: "yllapito.hoksinHakuOnnistui",
+          defaultMessage: ""
+        }),
+        isLoading: false,
+        hoksId: json.data.id
+      })
+    } else {
+      this.setState({
+        success: false,
+        message: intl.formatMessage({
+          id: "yllapito.hoksinHakuEpaonnistui",
+          defaultMessage: "Hoksin haku epäonnistui"
+        }),
+        isLoading: false
+      })
+    }
+  }
+
+  handleOidChange(event: any) {
+    const inputOid = event.target.value
+    this.setState({
+      opiskeluoikeusOid: inputOid
+    })
+    console.log(this.state.opiskeluoikeusOid)
+  }
+
   hideMessage = () => {
     this.setState({ message: "" })
   }
@@ -230,14 +285,81 @@ export class Yllapito extends React.Component<YllapitoProps> {
                   {message}
                 </SuccessMessage>
               ) : (
-                <FailureMessage onClick={this.hideMessage}>
-                  {message}
-                </FailureMessage>
-              )}
+                  <FailureMessage onClick={this.hideMessage}>
+                    {message}
+                  </FailureMessage>
+                )}
             </TopContainer>
             <ContentArea>
               {systemInfo && (
                 <ContentElement>
+                  <ContentElement>
+                    <Header>
+                      <FormattedMessage
+                        id="yllapito.oppijaIndeksiTitle"
+                        defaultMessage="Oppijaindeksi"
+                      />
+                    </Header>
+                    <ContentElement>
+                      <FormattedMessage
+                        id="yllapito.oppijaIndeksoimatta"
+                        defaultMessage="Indeksoimatta: {unindexed} oppijaa"
+                        values={{
+                          unindexed: systemInfo.oppijaindex.unindexedOppijat
+                        }}
+                      />
+                    </ContentElement>
+                  </ContentElement>
+                  <ContentElement>
+                    <Header>
+                      <FormattedMessage
+                        id="yllapito.hoksIdnHaku"
+                        defaultMessage="Hoks-id:n haku"
+                      />
+                    </Header>
+                    <ContentElement>
+                      <ContentElement>
+                        <form>
+                          <input
+                            type="text"
+                            value={this.state.opiskeluoikeusOid}
+                            onChange={this.handleOidChange.bind(this)}
+                          />
+                        </form>
+                      </ContentElement>
+                      <ContentElement>
+                        <Button onClick={this.onGetHoksId}>
+                          <FormattedMessage
+                            id="yllapito.haeHoksIdButton"
+                            defaultMessage="Hae hoks-id"
+                          />
+                        </Button>
+                      </ContentElement>
+                    </ContentElement>
+                    <FormattedMessage
+                      id="yllapito.hoksIdTulos"
+                      defaultMessage="Hoks-id on: {hoksId}"
+                      values={{
+                        hoksId:
+                          this.state.hoksId
+                      }}
+                    />
+                  </ContentElement>
+                  <ContentElement>
+                    <Header>
+                      <FormattedMessage
+                        id="yllapito.hoksienmaaraTitle"
+                        defaultMessage="Hoksien lukumäärä"
+                      />
+                    </Header>
+                    <ContentElement>
+                      <FormattedMessage
+                        id="yllapito.hoksienmaaraArvo"
+                        defaultMessage="Lukumäärä: {hoksAmount}"
+                        values={{ hoksAmount: systemInfo.hoksit.amount }}
+                      />
+                    </ContentElement>
+                  </ContentElement>
                   <ContentElement>
                     <Header>
                       <FormattedMessage

--- a/virkailija/translations.json
+++ b/virkailija/translations.json
@@ -212,6 +212,12 @@
     "yllapito.title": "Ylläpito",
     "yllapito.tyhjennaValimuisti": "Tyhjennä välimuisti",
     "yllapito.valimuistiKoko": "Koko: {cacheSize}",
-    "yllapito.valimuistiTitle": "Välimuisti"
+    "yllapito.valimuistiTitle": "Välimuisti",
+    "yllapito.hoksIdTulos": "Hoks-id on: {hoksId}",
+    "yllapito.hoksIdnHaku": "Hoks-id:n haku",
+    "yllapito.hoksienmaaraTitle": "Hoksien lukumäärä",
+    "yllapito.hoksienmaaraArvo": "Lukumäärä: {hoksAmount}",
+    "yllapito.hoksinHakuOnnistui": "Hoks-id:n haku onnistui",
+    "yllapito.hoksinHakuEpaonnistui": "Hoks-id:n haku epäonnistui"
   }
 }


### PR DESCRIPTION
Elikäs, ylläpitovälilehdelle vaan yksi nappu, joka hakee bäkkäristä opiskeluoikeus-oidilla ehoks-id:n sekä sitten vaan kälille tulostus hoksien määrästä eli yksi fetch bäkkäristä. Tuo Ylläpito.tsx näkyy vain oph-super-usereille. 

<img width="1211" alt="yllapitonaytto" src="https://user-images.githubusercontent.com/4289418/75543113-cb592f00-5a29-11ea-9bab-8d690ff454c5.png">
