### PR TITLE
Fix typescript issues with SessionStore

### DIFF
--- a/oppija/src/routes/OmienOpintojenSuunnittelu.tsx
+++ b/oppija/src/routes/OmienOpintojenSuunnittelu.tsx
@@ -13,9 +13,8 @@ import { BackgroundContainer } from "components/SectionContainer"
 import { SectionItem } from "components/SectionItem"
 import find from "lodash.find"
 import { observer } from "mobx-react"
-import { Instance } from "mobx-state-tree"
-import { HOKS } from "models/HOKS"
-import { SessionUser } from "models/SessionUser"
+import { IHOKS } from "models/HOKS"
+import { ISessionUser } from "models/SessionUser"
 import React from "react"
 import { MdEventNote, MdExtension } from "react-icons/md"
 import { FormattedMessage } from "react-intl"
@@ -49,8 +48,8 @@ const SectionItems = styled(ProgressPies)`
 `
 
 export interface OmienOpintojenSuunnitteluProps {
-  student: Instance<typeof SessionUser> | null
-  suunnitelmat: Instance<typeof HOKS>[]
+  student?: ISessionUser
+  suunnitelmat?: IHOKS[]
   path?: string
   id?: string
 }
@@ -73,7 +72,7 @@ export class OmienOpintojenSuunnittelu extends React.Component<
     const { id, student, suunnitelmat } = this.props
     const suunnitelma = find(suunnitelmat, s => s.eid === id)
 
-    if (!suunnitelma) {
+    if (!student || !suunnitelma) {
       return null
     }
 

--- a/oppija/src/stores/SessionStore.ts
+++ b/oppija/src/stores/SessionStore.ts
@@ -8,7 +8,7 @@ const SessionStoreModel = {
   error: types.optional(types.string, ""),
   settings: types.optional(Settings, {}),
   userDidLogout: false,
-  user: types.maybeNull(SessionUser),
+  user: types.maybe(SessionUser),
   selectedOrganisationOid: "",
   isLoading: types.optional(types.boolean, false)
 }
@@ -88,7 +88,7 @@ export const SessionStore = types
       self.isLoading = true
       try {
         yield deleteResource(apiUrl("oppija/session"), { headers: callerId() })
-        self.user = null
+        self.user = undefined
         self.userDidLogout = true
         self.isLoading = false
       } catch (error) {
@@ -112,7 +112,7 @@ export const SessionStore = types
   .views(self => {
     return {
       get isLoggedIn() {
-        return self.user !== null
+        return !!self.user
       }
     }
   })

--- a/oppija/src/stores/__tests__/SessionStore.test.ts
+++ b/oppija/src/stores/__tests__/SessionStore.test.ts
@@ -14,7 +14,7 @@ describe("SessionStore", () => {
     )
 
     expect(store.isLoading).toBe(false)
-    expect(store.user).toEqual(null)
+    expect(store.user).toBeUndefined()
 
     store.checkSession()
     expect(store.isLoading).toBe(true)
@@ -22,7 +22,7 @@ describe("SessionStore", () => {
     when(
       () => !store.isLoading,
       () => {
-        expect(store.user).toEqual(null)
+        expect(store.user).toBeUndefined()
       }
     )
   })
@@ -34,7 +34,7 @@ describe("SessionStore", () => {
     )
 
     expect(store.isLoading).toBe(false)
-    expect(store.user).toEqual(null)
+    expect(store.user).toBeUndefined()
 
     store.checkSession()
     expect(store.isLoading).toBe(true)
@@ -91,7 +91,7 @@ describe("SessionStore", () => {
     when(
       () => !store.isLoading,
       () => {
-        expect(store.user).toEqual(null)
+        expect(store.user).toBeUndefined()
       }
     )
   })

--- a/oppija/src/stores/__tests__/__snapshots__/RootStore.test.ts.snap
+++ b/oppija/src/stores/__tests__/__snapshots__/RootStore.test.ts.snap
@@ -37,7 +37,7 @@ Object {
         "userAcknowledgedIntroDialog": false,
       },
     },
-    "user": null,
+    "user": undefined,
     "userDidLogout": false,
   },
   "shareLinks": Object {},

--- a/shared/components/Opiskelija/Tavoitteet.tsx
+++ b/shared/components/Opiskelija/Tavoitteet.tsx
@@ -6,11 +6,10 @@ import { HelpPopup } from "components/HelpPopup"
 import { InfoTable } from "components/InfoTable"
 import { LabeledColumn } from "components/LabeledColumn"
 import { observer } from "mobx-react"
-import { Instance } from "mobx-state-tree"
-import { SessionUser } from "models/SessionUser"
+import { ISessionUser } from "models/SessionUser"
 import React from "react"
 import { FormattedMessage } from "react-intl"
-import { HOKS } from "models/HOKS"
+import { IHOKS } from "models/HOKS"
 import { AppContext } from "components/AppContext"
 import { FormattedDate } from "components/FormattedDate"
 
@@ -44,8 +43,8 @@ const OsaamisenHankkimisenTarveMessage = ({
 
 export interface TavoitteetProps {
   children?: React.ReactChildren
-  student: Instance<typeof SessionUser> | null
-  hoks: Instance<typeof HOKS>
+  student: ISessionUser
+  hoks: IHOKS
   titles?: {
     heading?: React.ReactNode
     goals?: React.ReactNode

--- a/shared/models/SessionUser.ts
+++ b/shared/models/SessionUser.ts
@@ -23,11 +23,11 @@ const ContactValue = types.model("ContactValue", {
 
 export const SessionUser = types
   .model("SessionUser", {
-    commonName: types.string,
-    contactValuesGroup: types.array(ContactValue),
+    commonName: types.optional(types.string, ""),
+    contactValuesGroup: types.optional(types.array(ContactValue), []),
     firstName: types.optional(types.string, ""),
     oid: types.optional(types.string, ""),
-    surname: types.string,
+    surname: types.optional(types.string, ""),
     fullName: types.optional(types.string, "")
   })
   .views(self => {

--- a/virkailija/src/stores/SessionStore.ts
+++ b/virkailija/src/stores/SessionStore.ts
@@ -22,7 +22,7 @@ const SessionStoreModel = {
   userDidLogout: false,
   user: types.maybe(VirkailijaUser),
   selectedOrganisationOid: types.optional(types.string, ""),
-  organisations: types.array(OrganisationModel)
+  organisations: types.optional(types.array(OrganisationModel), [])
 }
 
 export const SessionStore = types

--- a/virkailija/src/stores/SessionStore.ts
+++ b/virkailija/src/stores/SessionStore.ts
@@ -20,7 +20,7 @@ const SessionStoreModel = {
   error: types.optional(types.string, ""),
   isLoading: false,
   userDidLogout: false,
-  user: types.optional(types.union(VirkailijaUser, types.null), null),
+  user: types.maybe(VirkailijaUser),
   selectedOrganisationOid: types.optional(types.string, ""),
   organisations: types.array(OrganisationModel)
 }
@@ -103,7 +103,7 @@ export const SessionStore = types
         yield deleteResource(apiUrl("virkailija/session"), {
           headers: callerId()
         })
-        self.user = null
+        self.user = undefined
         self.isLoading = false
         self.userDidLogout = true
       } catch (error) {


### PR DESCRIPTION
This might be the first part of refactoring of technical debt related to TypeScript not finding issues.

- `OmienOpintojenSuunnittelu` was been rendered without `student: ISessionUser`.
- Removing `null`'s and using `undefined`'s as decided and used 3rd party libs suggest.
- Importing interfaces from models