### PR TITLE
Eh 843 replace harjoittelujaksot

### DIFF
--- a/shared/components/Opiskelija/AiempiOsaaminen.tsx
+++ b/shared/components/Opiskelija/AiempiOsaaminen.tsx
@@ -89,7 +89,6 @@ export class AiempiOsaaminen extends React.Component<
                     fadedColor="#ECF6ED"
                     title={study.opintoOtsikko(competencePointsTitle)}
                     learningPeriodsTEMP={study.osaamisenHankkimistavat}
-                    learningPeriods={study.harjoittelujaksot}
                     competenceRequirements={study.osaamisvaatimukset}
                     demonstrations={study.naytot}
                     verificationProcess={study.todentamisenProsessi}

--- a/shared/components/Opiskelija/AiempiOsaaminen.tsx
+++ b/shared/components/Opiskelija/AiempiOsaaminen.tsx
@@ -88,6 +88,7 @@ export class AiempiOsaaminen extends React.Component<
                     accentColor="#43A047"
                     fadedColor="#ECF6ED"
                     title={study.opintoOtsikko(competencePointsTitle)}
+                    learningPeriodsTEMP={study.osaamisenHankkimistavat}
                     learningPeriods={study.harjoittelujaksot}
                     competenceRequirements={study.osaamisvaatimukset}
                     demonstrations={study.naytot}

--- a/shared/components/Opiskelija/StudyPlan/CompletedStudies.tsx
+++ b/shared/components/Opiskelija/StudyPlan/CompletedStudies.tsx
@@ -74,6 +74,7 @@ export class CompletedStudies extends React.Component<CompletedStudiesProps> {
                   }
                   fadedColor="#ECF6ED"
                   koodiUri={study.tutkinnonOsaKoodiUri}
+                  learningPeriodsTEMP={study.osaamisenHankkimistavat}
                   learningPeriods={study.harjoittelujaksot}
                   share={share}
                   title={study.opintoOtsikko(competencePointsTitle)}

--- a/shared/components/Opiskelija/StudyPlan/CompletedStudies.tsx
+++ b/shared/components/Opiskelija/StudyPlan/CompletedStudies.tsx
@@ -75,7 +75,6 @@ export class CompletedStudies extends React.Component<CompletedStudiesProps> {
                   fadedColor="#ECF6ED"
                   koodiUri={study.tutkinnonOsaKoodiUri}
                   learningPeriodsTEMP={study.osaamisenHankkimistavat}
-                  learningPeriods={study.harjoittelujaksot}
                   share={share}
                   title={study.opintoOtsikko(competencePointsTitle)}
                   objectives={study.tavoitteetJaSisallot}

--- a/shared/components/Opiskelija/StudyPlan/PlannedStudies.tsx
+++ b/shared/components/Opiskelija/StudyPlan/PlannedStudies.tsx
@@ -75,7 +75,6 @@ export class PlannedStudies extends React.Component<PlannedStudiesProps> {
                   fadedColor="#FDF1E6"
                   koodiUri={study.tutkinnonOsaKoodiUri}
                   learningPeriodsTEMP={study.osaamisenHankkimistavat}
-                  learningPeriods={study.harjoittelujaksot}
                   share={share}
                   title={study.opintoOtsikko(competencePointsTitle)}
                   objectives={study.tavoitteetJaSisallot}

--- a/shared/components/Opiskelija/StudyPlan/PlannedStudies.tsx
+++ b/shared/components/Opiskelija/StudyPlan/PlannedStudies.tsx
@@ -74,6 +74,7 @@ export class PlannedStudies extends React.Component<PlannedStudiesProps> {
                   }
                   fadedColor="#FDF1E6"
                   koodiUri={study.tutkinnonOsaKoodiUri}
+                  learningPeriodsTEMP={study.osaamisenHankkimistavat}
                   learningPeriods={study.harjoittelujaksot}
                   share={share}
                   title={study.opintoOtsikko(competencePointsTitle)}

--- a/shared/components/Opiskelija/StudyPlan/ScheduledStudies.tsx
+++ b/shared/components/Opiskelija/StudyPlan/ScheduledStudies.tsx
@@ -74,6 +74,7 @@ export class ScheduledStudies extends React.Component<ScheduledStudiesProps> {
                   }
                   fadedColor="#FDF6E9"
                   koodiUri={study.tutkinnonOsaKoodiUri}
+                  learningPeriodsTEMP={study.osaamisenHankkimistavat}
                   learningPeriods={study.harjoittelujaksot}
                   share={share}
                   title={study.opintoOtsikko(competencePointsTitle)}

--- a/shared/components/Opiskelija/StudyPlan/ScheduledStudies.tsx
+++ b/shared/components/Opiskelija/StudyPlan/ScheduledStudies.tsx
@@ -75,7 +75,6 @@ export class ScheduledStudies extends React.Component<ScheduledStudiesProps> {
                   fadedColor="#FDF6E9"
                   koodiUri={study.tutkinnonOsaKoodiUri}
                   learningPeriodsTEMP={study.osaamisenHankkimistavat}
-                  learningPeriods={study.harjoittelujaksot}
                   share={share}
                   title={study.opintoOtsikko(competencePointsTitle)}
                   objectives={study.tavoitteetJaSisallot}

--- a/shared/components/StudyInfo.tsx
+++ b/shared/components/StudyInfo.tsx
@@ -297,6 +297,7 @@ export class StudyInfo extends React.Component<StudyInfoProps, StudyInfoState> {
               extraContent={extraContent}
               expanded={detailsExpanded}
               learningPeriods={learningPeriods}
+              learningPeriodsTEMP={learningPeriodsTEMP}
               competenceAcquiringMethods={competenceAcquiringMethods}
               verificationProcess={verificationProcess}
               koodiUri={koodiUri}

--- a/shared/components/StudyInfo.tsx
+++ b/shared/components/StudyInfo.tsx
@@ -5,7 +5,6 @@ import { Details } from "./StudyInfo/Details"
 import {
   Osaamisvaatimus,
   Naytto,
-  Harjoittelujakso,
   TodentamisenProsessi,
   OsaamisenHankkimistapa
 } from "models/helpers/TutkinnonOsa"
@@ -110,17 +109,10 @@ export interface StudyInfoProps {
    */
   koodiUri?: string
   /**
-   * List of learning periods, this is going to replace deprecated learningPeriods
+   * List of learning periods.
    * @default []
-   * @deprecated
    */
   learningPeriodsTEMP?: Array<OsaamisenHankkimistapa>
-  /**
-   * List of learning periods
-   * @default []
-   * @deprecated
-   */
-  learningPeriods?: Array<Harjoittelujakso>
   /**
    * Current share state from url
    */
@@ -244,7 +236,6 @@ export class StudyInfo extends React.Component<StudyInfoProps, StudyInfoState> {
       extraContent = null,
       fadedColor,
       learningPeriodsTEMP = [],
-      learningPeriods = [],
       koodiUri,
       share,
       title,

--- a/shared/components/StudyInfo.tsx
+++ b/shared/components/StudyInfo.tsx
@@ -110,8 +110,15 @@ export interface StudyInfoProps {
    */
   koodiUri?: string
   /**
+   * List of learning periods, this is going to replace deprecated learningPeriods
+   * @default []
+   * @deprecated
+   */
+  learningPeriodsTEMP?: Array<OsaamisenHankkimistapa>
+  /**
    * List of learning periods
    * @default []
+   * @deprecated
    */
   learningPeriods?: Array<Harjoittelujakso>
   /**
@@ -236,6 +243,7 @@ export class StudyInfo extends React.Component<StudyInfoProps, StudyInfoState> {
       demonstrations = [],
       extraContent = null,
       fadedColor,
+      learningPeriodsTEMP = [],
       learningPeriods = [],
       koodiUri,
       share,
@@ -246,7 +254,8 @@ export class StudyInfo extends React.Component<StudyInfoProps, StudyInfoState> {
     } = this.props
     const { featureFlags } = this.context
     const { expandedCompetences, expanded } = this.state
-    const hasLearningPeriods = learningPeriods && learningPeriods.length > 0
+    const hasLearningPeriods =
+      learningPeriodsTEMP && learningPeriodsTEMP.length > 0
     const hasDetails =
       hasLearningPeriods || demonstrations.length > 0 || verificationProcess
     const hasActiveShare =

--- a/shared/components/StudyInfo.tsx
+++ b/shared/components/StudyInfo.tsx
@@ -296,7 +296,6 @@ export class StudyInfo extends React.Component<StudyInfoProps, StudyInfoState> {
               demonstrations={demonstrations}
               extraContent={extraContent}
               expanded={detailsExpanded}
-              learningPeriods={learningPeriods}
               learningPeriodsTEMP={learningPeriodsTEMP}
               competenceAcquiringMethods={competenceAcquiringMethods}
               verificationProcess={verificationProcess}

--- a/shared/components/StudyInfo/Details.tsx
+++ b/shared/components/StudyInfo/Details.tsx
@@ -77,7 +77,6 @@ interface DetailsProps {
   expanded?: boolean
   koodiUri?: string
   learningPeriodsTEMP?: Array<OsaamisenHankkimistapa>
-  learningPeriods?: Array<Harjoittelujakso>
   competenceAcquiringMethods?: Array<OsaamisenHankkimistapa>
   share?: { koodiUri: string; type: ShareType | "" }
   toggle: (name: ToggleableItems) => () => void
@@ -97,7 +96,6 @@ export class Details extends React.Component<DetailsProps> {
       fadedColor = "",
       koodiUri,
       learningPeriodsTEMP = [],
-      learningPeriods = [],
       competenceAcquiringMethods = [],
       share,
       toggle,

--- a/shared/components/StudyInfo/Details.tsx
+++ b/shared/components/StudyInfo/Details.tsx
@@ -144,9 +144,6 @@ export class Details extends React.Component<DetailsProps> {
           otherPeriods.push(ymparisto)
         )
       })
-    const organizer =
-      competenceAcquiringMethods[0] &&
-      competenceAcquiringMethods[0].jarjestajanEdustaja
 
     return expanded ? (
       <DetailsExpanded

--- a/shared/components/StudyInfo/Details.tsx
+++ b/shared/components/StudyInfo/Details.tsx
@@ -175,14 +175,23 @@ export class Details extends React.Component<DetailsProps> {
             instructor={instructor}
             defaultPeriod={defaultPeriod}
           >
+            {/*TODO EH-843*/}
             {learningPeriods.map((period, i) => {
+              // {learningPeriodsTEMP.map((period, i) => {
               return (
+                // TODO EH-843
                 <LearningPeriod
                   key={i}
                   learningPeriod={period}
                   competenceAcquiringMethods={competenceAcquiringMethods}
                   organizer={organizer}
                 />
+                // <LearningPeriodTEMP
+                //   key={i}
+                //   learningPeriodTEMP={period}
+                //   competenceAcquiringMethods={competenceAcquiringMethods}
+                //   organizer={organizer}
+                // />
               )
             })}
           </ShareDialog>

--- a/shared/components/StudyInfo/Details.tsx
+++ b/shared/components/StudyInfo/Details.tsx
@@ -5,7 +5,7 @@ import { Collapse } from "./Collapse"
 import { Demonstration } from "./Demonstration"
 import { Expand } from "./Expand"
 import { IconContainer } from "./IconContainer"
-import { LearningPeriodTEMP } from "./LearningPeriod"
+import { LearningPeriod } from "./LearningPeriod"
 import { OtherPeriod } from "./OtherPeriod"
 import {
   Harjoittelujakso,
@@ -173,7 +173,7 @@ export class Details extends React.Component<DetailsProps> {
             defaultPeriod={defaultPeriod}
           >
             {learningPeriodsTEMP.map((period, i) => {
-              return <LearningPeriodTEMP key={i} learningPeriodTEMP={period} />
+              return <LearningPeriod key={i} learningPeriod={period} />
             })}
           </ShareDialog>
 

--- a/shared/components/StudyInfo/Details.tsx
+++ b/shared/components/StudyInfo/Details.tsx
@@ -8,7 +8,6 @@ import { IconContainer } from "./IconContainer"
 import { LearningPeriod } from "./LearningPeriod"
 import { OtherPeriod } from "./OtherPeriod"
 import {
-  Harjoittelujakso,
   MuuOppimisymparisto,
   Naytto,
   OsaamisenHankkimistapa,

--- a/shared/components/StudyInfo/Details.tsx
+++ b/shared/components/StudyInfo/Details.tsx
@@ -21,6 +21,7 @@ import parseISO from "date-fns/parseISO"
 import { ShareType } from "stores/NotificationStore"
 import ShareDialog from "components/ShareDialog"
 import { ToggleableItems } from "./StudyInfoHelpers"
+import { OsaamisenHankkimistapaType } from "../../models/OsaamisenHankkimistapa"
 
 interface ColorProps {
   fadedColor: string
@@ -245,7 +246,7 @@ export class Details extends React.Component<DetailsProps> {
                 <LearningEvent
                   key={i}
                   title={
-                    lp.tyyppi === "OTHER" ? (
+                    lp.tyyppi === OsaamisenHankkimistapaType.Other ? (
                       lp.nimi
                     ) : (
                       <FormattedMessage

--- a/shared/components/StudyInfo/Details.tsx
+++ b/shared/components/StudyInfo/Details.tsx
@@ -5,7 +5,7 @@ import { Collapse } from "./Collapse"
 import { Demonstration } from "./Demonstration"
 import { Expand } from "./Expand"
 import { IconContainer } from "./IconContainer"
-import { LearningPeriod } from "./LearningPeriod"
+import { LearningPeriodTEMP } from "./LearningPeriod"
 import { OtherPeriod } from "./OtherPeriod"
 import {
   Harjoittelujakso,
@@ -175,24 +175,8 @@ export class Details extends React.Component<DetailsProps> {
             instructor={instructor}
             defaultPeriod={defaultPeriod}
           >
-            {/*TODO EH-843*/}
-            {learningPeriods.map((period, i) => {
-              // {learningPeriodsTEMP.map((period, i) => {
-              return (
-                // TODO EH-843
-                <LearningPeriod
-                  key={i}
-                  learningPeriod={period}
-                  competenceAcquiringMethods={competenceAcquiringMethods}
-                  organizer={organizer}
-                />
-                // <LearningPeriodTEMP
-                //   key={i}
-                //   learningPeriodTEMP={period}
-                //   competenceAcquiringMethods={competenceAcquiringMethods}
-                //   organizer={organizer}
-                // />
-              )
+            {learningPeriodsTEMP.map((period, i) => {
+              return <LearningPeriodTEMP key={i} learningPeriodTEMP={period} />
             })}
           </ShareDialog>
 

--- a/shared/components/StudyInfo/Details.tsx
+++ b/shared/components/StudyInfo/Details.tsx
@@ -115,8 +115,8 @@ export class Details extends React.Component<DetailsProps> {
       typeof share !== "undefined" && koodiUri === share.koodiUri
     const shareType = typeof share !== "undefined" ? share.type : undefined
     const firstLearningPeriod =
-      shareType === "tyossaoppiminen" && learningPeriods[0]
-        ? learningPeriods[0]
+      shareType === "tyossaoppiminen" && learningPeriodsTEMP[0]
+        ? learningPeriodsTEMP[0]
         : undefined
 
     const instructor = firstLearningPeriod
@@ -242,7 +242,7 @@ export class Details extends React.Component<DetailsProps> {
                 />
               </VerificationTitle>
             )}
-            {learningPeriods.map((lp, i) => {
+            {learningPeriodsTEMP.map((lp, i) => {
               return (
                 <LearningEvent
                   key={i}

--- a/shared/components/StudyInfo/Details.tsx
+++ b/shared/components/StudyInfo/Details.tsx
@@ -76,6 +76,7 @@ interface DetailsProps {
   extraContent?: React.ReactNode
   expanded?: boolean
   koodiUri?: string
+  learningPeriodsTEMP?: Array<OsaamisenHankkimistapa>
   learningPeriods?: Array<Harjoittelujakso>
   competenceAcquiringMethods?: Array<OsaamisenHankkimistapa>
   share?: { koodiUri: string; type: ShareType | "" }
@@ -95,6 +96,7 @@ export class Details extends React.Component<DetailsProps> {
       expanded,
       fadedColor = "",
       koodiUri,
+      learningPeriodsTEMP = [],
       learningPeriods = [],
       competenceAcquiringMethods = [],
       share,
@@ -107,7 +109,7 @@ export class Details extends React.Component<DetailsProps> {
     const { SUORAAN, ARVIOIJIEN_KAUTTA, OHJAUS_NAYTTOON } = VerificationProcess
     const showExpand =
       demonstrations.length ||
-      learningPeriods.length ||
+      learningPeriodsTEMP.length ||
       verification === OHJAUS_NAYTTOON
     const hasActiveShare =
       typeof share !== "undefined" && koodiUri === share.koodiUri

--- a/shared/components/StudyInfo/LearningPeriod.tsx
+++ b/shared/components/StudyInfo/LearningPeriod.tsx
@@ -177,9 +177,9 @@ export class LearningPeriodTEMP extends React.Component<
 > {
   render() {
     const {
-      learningPeriodTEMP
+      learningPeriodTEMP,
       // competenceAcquiringMethods,
-      // organizer
+      organizer
     } = this.props
     const {
       alku,
@@ -201,11 +201,12 @@ export class LearningPeriodTEMP extends React.Component<
       tyyppi === "WORKPLACE" && tyopaikallaJarjestettavaKoulutus
         ? selite + ", " + tyopaikallaJarjestettavaKoulutus.tyopaikanYTunnus
         : selite
-    // const organizerRepresentative =
-    //   organizer && organizer.nimi ? organizer.nimi : ""
+    const organizerRepresentative =
+      organizer && organizer.nimi ? organizer.nimi : ""
     // TODO EH-757, this need to be fixed. Comment out after competenceAqcquiringMethods have been removed and
     // harjoittelujaksot replaced with osaamisenHankkimistapa
-    // const organizerOrganisation = organizer && organizer.oppilaitosNimi ? organizer.oppilaitosNimi : ""
+    const organizerOrganisation =
+      organizer && organizer.oppilaitosNimi ? organizer.oppilaitosNimi : ""
 
     return (
       <Container data-testid="StudyInfo.LearningPeriod">
@@ -248,20 +249,20 @@ export class LearningPeriodTEMP extends React.Component<
                 </TD>
               </tr>
             )}
-            {/*{tyyppi === "WORKPLACE" && ohjaaja && (*/}
-            {/*  <tr>*/}
-            {/*    <TH>*/}
-            {/*      <FormattedMessage*/}
-            {/*        id="opiskelusuunnitelma.koulutuksenjarjestajanEdustajaTitle"*/}
-            {/*        defaultMessage="Koulutuksen järjestäjän edustaja"*/}
-            {/*      />*/}
-            {/*    </TH>*/}
-            {/*    <TD>*/}
-            {/*      /!*TODO EH-757 add organizerOrgansation here, see comment above*!/*/}
-            {/*      {organizerRepresentative}*/}
-            {/*    </TD>*/}
-            {/*  </tr>*/}
-            {/*)}*/}
+            {tyyppi === "WORKPLACE" && vastuullinenTyopaikkaOhjaaja && (
+              <tr>
+                <TH>
+                  <FormattedMessage
+                    id="opiskelusuunnitelma.koulutuksenjarjestajanEdustajaTitle"
+                    defaultMessage="Koulutuksen järjestäjän edustaja"
+                  />
+                </TH>
+                <TD>
+                  {/*TODO EH-757 add organizerOrgansation here, see comment above*/}
+                  {organizerRepresentative}, {organizerOrganisation}
+                </TD>
+              </tr>
+            )}
             {/*{tyotehtavat.length > 0 && (*/}
             {/*  <tr>*/}
             {/*    <TH>*/}

--- a/shared/components/StudyInfo/LearningPeriod.tsx
+++ b/shared/components/StudyInfo/LearningPeriod.tsx
@@ -15,6 +15,7 @@ import {
 } from "./Shared"
 import { OsaamisenHankkimistapa } from "models/helpers/TutkinnonOsa"
 import { LearningEvent } from "components/StudyInfo/LearningEvent"
+import { OsaamisenHankkimistapaType } from "../../models/OsaamisenHankkimistapa"
 
 const LearningPeriodTitle = styled(Title)`
   margin-left: 20px;
@@ -64,7 +65,7 @@ export class LearningPeriod extends React.Component<LearningPeriodProps> {
           <LearningPeriodTitle>
             <LearningEvent
               title={
-                tyyppi === "OTHER" ? (
+                tyyppi === OsaamisenHankkimistapaType.Other ? (
                   nimi
                 ) : (
                   <FormattedMessage
@@ -74,7 +75,11 @@ export class LearningPeriod extends React.Component<LearningPeriodProps> {
                 )
               }
               type={tyyppi}
-              description={tyyppi === "WORKPLACE" ? workplaceSelite : selite}
+              description={
+                tyyppi === OsaamisenHankkimistapaType.Workplace
+                  ? workplaceSelite
+                  : selite
+              }
               startDate={alku}
               endDate={loppu}
               periodSpecifier={ajanjaksonTarkenne}
@@ -84,32 +89,34 @@ export class LearningPeriod extends React.Component<LearningPeriodProps> {
         )}
         <LearningPeriodTable>
           <TBody>
-            {tyyppi === "WORKPLACE" && vastuullinenTyopaikkaOhjaaja && (
-              <tr>
-                <TH>
-                  <FormattedMessage
-                    id="opiskelusuunnitelma.tyopaikkaohjaajaTitle"
-                    defaultMessage="Työpaikkaohjaaja"
-                  />
-                </TH>
-                <TD>
-                  {vastuullinenTyopaikkaOhjaaja.nimi}, {selite}
-                  <br />
-                  {vastuullinenTyopaikkaOhjaaja.sahkoposti}
-                </TD>
-              </tr>
-            )}
-            {tyyppi === "WORKPLACE" && vastuullinenTyopaikkaOhjaaja && (
-              <tr>
-                <TH>
-                  <FormattedMessage
-                    id="opiskelusuunnitelma.koulutuksenjarjestajanEdustajaTitle"
-                    defaultMessage="Koulutuksen järjestäjän edustaja"
-                  />
-                </TH>
-                <TD>{jarjestajanEdustaja.oppilaitosHenkiloDescription}</TD>
-              </tr>
-            )}
+            {tyyppi === OsaamisenHankkimistapaType.Workplace &&
+              vastuullinenTyopaikkaOhjaaja && (
+                <tr>
+                  <TH>
+                    <FormattedMessage
+                      id="opiskelusuunnitelma.tyopaikkaohjaajaTitle"
+                      defaultMessage="Työpaikkaohjaaja"
+                    />
+                  </TH>
+                  <TD>
+                    {vastuullinenTyopaikkaOhjaaja.nimi}, {selite}
+                    <br />
+                    {vastuullinenTyopaikkaOhjaaja.sahkoposti}
+                  </TD>
+                </tr>
+              )}
+            {tyyppi === OsaamisenHankkimistapaType.Workplace &&
+              vastuullinenTyopaikkaOhjaaja && (
+                <tr>
+                  <TH>
+                    <FormattedMessage
+                      id="opiskelusuunnitelma.koulutuksenjarjestajanEdustajaTitle"
+                      defaultMessage="Koulutuksen järjestäjän edustaja"
+                    />
+                  </TH>
+                  <TD>{jarjestajanEdustaja.oppilaitosHenkiloDescription}</TD>
+                </tr>
+              )}
             {keskeisetTyotehtavat.length > 0 && (
               <tr>
                 <TH>

--- a/shared/components/StudyInfo/LearningPeriod.tsx
+++ b/shared/components/StudyInfo/LearningPeriod.tsx
@@ -181,21 +181,23 @@ export class LearningPeriodTEMP extends React.Component<
       // competenceAcquiringMethods,
       // organizer
     } = this.props
-    const { alku, loppu, nimi } = learningPeriodTEMP
+    const {
+      alku,
+      loppu,
+      nimi,
+      tyyppi,
+      tyopaikallaJarjestettavaKoulutus,
+      selite,
+      ajanjaksonTarkenne
+    } = learningPeriodTEMP
 
     // const method = competenceAcquiringMethods
     //   ? competenceAcquiringMethods[0]
     //   : undefined
-    // const workplaceSelite =
-    //   tyyppi === "WORKPLACE" &&
-    //   method &&
-    //   method.tyopaikallaJarjestettavaKoulutus
-    //     ? selite +
-    //       ", " +
-    //       method.tyopaikallaJarjestettavaKoulutus.tyopaikanYTunnus
-    //     : selite
-    // const periodSpecifier =
-    //   method && method.ajanjaksonTarkenne ? method.ajanjaksonTarkenne : ""
+    const workplaceSelite =
+      tyyppi === "WORKPLACE" && tyopaikallaJarjestettavaKoulutus
+        ? selite + ", " + tyopaikallaJarjestettavaKoulutus.tyopaikanYTunnus
+        : selite
     // const organizerRepresentative =
     //   organizer && organizer.nimi ? organizer.nimi : ""
     // TODO EH-757, this need to be fixed. Comment out after competenceAqcquiringMethods have been removed and
@@ -204,29 +206,28 @@ export class LearningPeriodTEMP extends React.Component<
 
     return (
       <Container data-testid="StudyInfo.LearningPeriod">
-        TESTIA {alku}, {loppu}, {nimi}
-        {/*{(alku || loppu) && (*/}
-        {/*  <LearningPeriodTitle>*/}
-        {/*    <LearningEvent*/}
-        {/*      title={*/}
-        {/*        tyyppi === "OTHER" ? (*/}
-        {/*          nimi*/}
-        {/*        ) : (*/}
-        {/*          <FormattedMessage*/}
-        {/*            id="opiskelusuunnitelma.tyossaoppiminenTitle"*/}
-        {/*            defaultMessage="Työpaikalla oppiminen"*/}
-        {/*          />*/}
-        {/*        )*/}
-        {/*      }*/}
-        {/*      type={tyyppi}*/}
-        {/*      description={tyyppi === "WORKPLACE" ? workplaceSelite : selite}*/}
-        {/*      startDate={alku}*/}
-        {/*      endDate={loppu}*/}
-        {/*      periodSpecifier={periodSpecifier}*/}
-        {/*      size="large"*/}
-        {/*    />*/}
-        {/*  </LearningPeriodTitle>*/}
-        {/*)}*/}
+        {(alku || loppu) && (
+          <LearningPeriodTitle>
+            <LearningEvent
+              title={
+                tyyppi === "OTHER" ? (
+                  nimi
+                ) : (
+                  <FormattedMessage
+                    id="opiskelusuunnitelma.tyossaoppiminenTitle"
+                    defaultMessage="Työpaikalla oppiminen"
+                  />
+                )
+              }
+              type={tyyppi}
+              description={tyyppi === "WORKPLACE" ? workplaceSelite : selite}
+              startDate={alku}
+              endDate={loppu}
+              periodSpecifier={ajanjaksonTarkenne}
+              size="large"
+            />
+          </LearningPeriodTitle>
+        )}
         {/*<LearningPeriodTable>*/}
         {/*  <TBody>*/}
         {/*    {tyyppi === "WORKPLACE" && ohjaaja && (*/}

--- a/shared/components/StudyInfo/LearningPeriod.tsx
+++ b/shared/components/StudyInfo/LearningPeriod.tsx
@@ -188,25 +188,17 @@ export class LearningPeriodTEMP extends React.Component<
       tyyppi,
       tyopaikallaJarjestettavaKoulutus,
       selite,
-      ajanjaksonTarkenne
+      ajanjaksonTarkenne,
+      jarjestajanEdustaja
     } = learningPeriodTEMP
 
     const vastuullinenTyopaikkaOhjaaja =
       tyopaikallaJarjestettavaKoulutus?.vastuullinenTyopaikkaOhjaaja
 
-    // const method = competenceAcquiringMethods
-    //   ? competenceAcquiringMethods[0]
-    //   : undefined
     const workplaceSelite =
       tyyppi === "WORKPLACE" && tyopaikallaJarjestettavaKoulutus
         ? selite + ", " + tyopaikallaJarjestettavaKoulutus.tyopaikanYTunnus
         : selite
-    const organizerRepresentative =
-      organizer && organizer.nimi ? organizer.nimi : ""
-    // TODO EH-757, this need to be fixed. Comment out after competenceAqcquiringMethods have been removed and
-    // harjoittelujaksot replaced with osaamisenHankkimistapa
-    const organizerOrganisation =
-      organizer && organizer.oppilaitosNimi ? organizer.oppilaitosNimi : ""
 
     return (
       <Container data-testid="StudyInfo.LearningPeriod">
@@ -257,10 +249,7 @@ export class LearningPeriodTEMP extends React.Component<
                     defaultMessage="Koulutuksen järjestäjän edustaja"
                   />
                 </TH>
-                <TD>
-                  {/*TODO EH-757 add organizerOrgansation here, see comment above*/}
-                  {organizerRepresentative}, {organizerOrganisation}
-                </TD>
+                <TD>{jarjestajanEdustaja.oppilaitosHenkiloDescription}</TD>
               </tr>
             )}
             {/*{tyotehtavat.length > 0 && (*/}

--- a/shared/components/StudyInfo/LearningPeriod.tsx
+++ b/shared/components/StudyInfo/LearningPeriod.tsx
@@ -33,15 +33,13 @@ const CustomSlider = styled(MobileSlider)`
   margin: 10px 20px 20px 10px;
 `
 
-interface LearningPeriodTEMPProps {
-  learningPeriodTEMP: OsaamisenHankkimistapa
+interface LearningPeriodProps {
+  learningPeriod: OsaamisenHankkimistapa
 }
 
-export class LearningPeriodTEMP extends React.Component<
-  LearningPeriodTEMPProps
-> {
+export class LearningPeriod extends React.Component<LearningPeriodProps> {
   render() {
-    const { learningPeriodTEMP } = this.props
+    const { learningPeriod } = this.props
     const {
       alku,
       loppu,
@@ -52,7 +50,7 @@ export class LearningPeriodTEMP extends React.Component<
       workplaceSelite,
       ajanjaksonTarkenne,
       jarjestajanEdustaja
-    } = learningPeriodTEMP
+    } = learningPeriod
 
     const vastuullinenTyopaikkaOhjaaja =
       tyopaikallaJarjestettavaKoulutus?.vastuullinenTyopaikkaOhjaaja

--- a/shared/components/StudyInfo/LearningPeriod.tsx
+++ b/shared/components/StudyInfo/LearningPeriod.tsx
@@ -49,6 +49,7 @@ export class LearningPeriodTEMP extends React.Component<
       tyyppi,
       tyopaikallaJarjestettavaKoulutus,
       selite,
+      workplaceSelite,
       ajanjaksonTarkenne,
       jarjestajanEdustaja
     } = learningPeriodTEMP
@@ -58,11 +59,6 @@ export class LearningPeriodTEMP extends React.Component<
 
     const keskeisetTyotehtavat =
       tyopaikallaJarjestettavaKoulutus?.keskeisetTyotehtavat
-
-    const workplaceSelite =
-      tyyppi === "WORKPLACE" && tyopaikallaJarjestettavaKoulutus
-        ? selite + ", " + tyopaikallaJarjestettavaKoulutus.tyopaikanYTunnus
-        : selite
 
     return (
       <Container data-testid="StudyInfo.LearningPeriod">

--- a/shared/components/StudyInfo/LearningPeriod.tsx
+++ b/shared/components/StudyInfo/LearningPeriod.tsx
@@ -114,10 +114,10 @@ export class LearningPeriod extends React.Component<LearningPeriodProps> {
                       defaultMessage="Koulutuksen järjestäjän edustaja"
                     />
                   </TH>
-                  <TD>{jarjestajanEdustaja.oppilaitosHenkiloDescription}</TD>
+                  <TD>{jarjestajanEdustaja?.oppilaitosHenkiloDescription}</TD>
                 </tr>
               )}
-            {keskeisetTyotehtavat.length > 0 && (
+            {keskeisetTyotehtavat?.length > 0 && (
               <tr>
                 <TH>
                   <FormattedMessage
@@ -130,7 +130,7 @@ export class LearningPeriod extends React.Component<LearningPeriodProps> {
             )}
           </TBody>
         </LearningPeriodTable>
-        {keskeisetTyotehtavat.length > 0 && (
+        {keskeisetTyotehtavat?.length > 0 && (
           <React.Fragment>
             <HMediaQuery.MaxWidth breakpoint="Tablet">
               <CustomSlider>

--- a/shared/components/StudyInfo/LearningPeriod.tsx
+++ b/shared/components/StudyInfo/LearningPeriod.tsx
@@ -191,6 +191,9 @@ export class LearningPeriodTEMP extends React.Component<
       ajanjaksonTarkenne
     } = learningPeriodTEMP
 
+    const vastuullinenTyopaikkaOhjaaja =
+      tyopaikallaJarjestettavaKoulutus?.vastuullinenTyopaikkaOhjaaja
+
     // const method = competenceAcquiringMethods
     //   ? competenceAcquiringMethods[0]
     //   : undefined
@@ -228,50 +231,50 @@ export class LearningPeriodTEMP extends React.Component<
             />
           </LearningPeriodTitle>
         )}
-        {/*<LearningPeriodTable>*/}
-        {/*  <TBody>*/}
-        {/*    {tyyppi === "WORKPLACE" && ohjaaja && (*/}
-        {/*      <tr>*/}
-        {/*        <TH>*/}
-        {/*          <FormattedMessage*/}
-        {/*            id="opiskelusuunnitelma.tyopaikkaohjaajaTitle"*/}
-        {/*            defaultMessage="Työpaikkaohjaaja"*/}
-        {/*          />*/}
-        {/*        </TH>*/}
-        {/*        <TD>*/}
-        {/*          {ohjaaja.nimi}, {selite}*/}
-        {/*          <br />*/}
-        {/*          {ohjaaja.sahkoposti}*/}
-        {/*        </TD>*/}
-        {/*      </tr>*/}
-        {/*    )}*/}
-        {/*    {tyyppi === "WORKPLACE" && ohjaaja && (*/}
-        {/*      <tr>*/}
-        {/*        <TH>*/}
-        {/*          <FormattedMessage*/}
-        {/*            id="opiskelusuunnitelma.koulutuksenjarjestajanEdustajaTitle"*/}
-        {/*            defaultMessage="Koulutuksen järjestäjän edustaja"*/}
-        {/*          />*/}
-        {/*        </TH>*/}
-        {/*        <TD>*/}
-        {/*          /!*TODO EH-757 add organizerOrgansation here, see comment above*!/*/}
-        {/*          {organizerRepresentative}*/}
-        {/*        </TD>*/}
-        {/*      </tr>*/}
-        {/*    )}*/}
-        {/*    {tyotehtavat.length > 0 && (*/}
-        {/*      <tr>*/}
-        {/*        <TH>*/}
-        {/*          <FormattedMessage*/}
-        {/*            id="opiskelusuunnitelma.keskeisetTyotehtavatTitle"*/}
-        {/*            defaultMessage="Keskeiset työtehtävät"*/}
-        {/*          />*/}
-        {/*        </TH>*/}
-        {/*        <EmptyTD />*/}
-        {/*      </tr>*/}
-        {/*    )}*/}
-        {/*  </TBody>*/}
-        {/*</LearningPeriodTable>*/}
+        <LearningPeriodTable>
+          <TBody>
+            {tyyppi === "WORKPLACE" && vastuullinenTyopaikkaOhjaaja && (
+              <tr>
+                <TH>
+                  <FormattedMessage
+                    id="opiskelusuunnitelma.tyopaikkaohjaajaTitle"
+                    defaultMessage="Työpaikkaohjaaja"
+                  />
+                </TH>
+                <TD>
+                  {vastuullinenTyopaikkaOhjaaja.nimi}, {selite}
+                  <br />
+                  {vastuullinenTyopaikkaOhjaaja.sahkoposti}
+                </TD>
+              </tr>
+            )}
+            {/*{tyyppi === "WORKPLACE" && ohjaaja && (*/}
+            {/*  <tr>*/}
+            {/*    <TH>*/}
+            {/*      <FormattedMessage*/}
+            {/*        id="opiskelusuunnitelma.koulutuksenjarjestajanEdustajaTitle"*/}
+            {/*        defaultMessage="Koulutuksen järjestäjän edustaja"*/}
+            {/*      />*/}
+            {/*    </TH>*/}
+            {/*    <TD>*/}
+            {/*      /!*TODO EH-757 add organizerOrgansation here, see comment above*!/*/}
+            {/*      {organizerRepresentative}*/}
+            {/*    </TD>*/}
+            {/*  </tr>*/}
+            {/*)}*/}
+            {/*{tyotehtavat.length > 0 && (*/}
+            {/*  <tr>*/}
+            {/*    <TH>*/}
+            {/*      <FormattedMessage*/}
+            {/*        id="opiskelusuunnitelma.keskeisetTyotehtavatTitle"*/}
+            {/*        defaultMessage="Keskeiset työtehtävät"*/}
+            {/*      />*/}
+            {/*    </TH>*/}
+            {/*    <EmptyTD />*/}
+            {/*  </tr>*/}
+            {/*)}*/}
+          </TBody>
+        </LearningPeriodTable>
         {/*{tyotehtavat.length > 0 && (*/}
         {/*  <React.Fragment>*/}
         {/*    <HMediaQuery.MaxWidth breakpoint="Tablet">*/}

--- a/shared/components/StudyInfo/LearningPeriod.tsx
+++ b/shared/components/StudyInfo/LearningPeriod.tsx
@@ -13,11 +13,7 @@ import {
   TH,
   Title
 } from "./Shared"
-import {
-  Harjoittelujakso,
-  JarjestajanEdustaja,
-  OsaamisenHankkimistapa
-} from "models/helpers/TutkinnonOsa"
+import { OsaamisenHankkimistapa } from "models/helpers/TutkinnonOsa"
 import { LearningEvent } from "components/StudyInfo/LearningEvent"
 
 const LearningPeriodTitle = styled(Title)`
@@ -37,150 +33,15 @@ const CustomSlider = styled(MobileSlider)`
   margin: 10px 20px 20px 10px;
 `
 
-interface LearningPeriodProps {
-  learningPeriod: Harjoittelujakso
-  competenceAcquiringMethods?: Array<OsaamisenHankkimistapa>
-  organizer?: JarjestajanEdustaja
-}
-
-export class LearningPeriod extends React.Component<LearningPeriodProps> {
-  render() {
-    const { learningPeriod, competenceAcquiringMethods, organizer } = this.props
-    const {
-      tyotehtavat = [],
-      alku,
-      loppu,
-      nimi,
-      tyyppi,
-      ohjaaja,
-      selite
-    } = learningPeriod
-
-    const method = competenceAcquiringMethods
-      ? competenceAcquiringMethods[0]
-      : undefined
-    const workplaceSelite =
-      tyyppi === "WORKPLACE" &&
-      method &&
-      method.tyopaikallaJarjestettavaKoulutus
-        ? selite +
-          ", " +
-          method.tyopaikallaJarjestettavaKoulutus.tyopaikanYTunnus
-        : selite
-    const periodSpecifier =
-      method && method.ajanjaksonTarkenne ? method.ajanjaksonTarkenne : ""
-    const organizerRepresentative =
-      organizer && organizer.nimi ? organizer.nimi : ""
-    // TODO EH-757, this need to be fixed. Comment out after competenceAqcquiringMethods have been removed and
-    // harjoittelujaksot replaced with osaamisenHankkimistapa
-    // const organizerOrganisation = organizer && organizer.oppilaitosNimi ? organizer.oppilaitosNimi : ""
-
-    return (
-      <Container data-testid="StudyInfo.LearningPeriod">
-        {(alku || loppu) && (
-          <LearningPeriodTitle>
-            <LearningEvent
-              title={
-                tyyppi === "OTHER" ? (
-                  nimi
-                ) : (
-                  <FormattedMessage
-                    id="opiskelusuunnitelma.tyossaoppiminenTitle"
-                    defaultMessage="Työpaikalla oppiminen"
-                  />
-                )
-              }
-              type={tyyppi}
-              description={tyyppi === "WORKPLACE" ? workplaceSelite : selite}
-              startDate={alku}
-              endDate={loppu}
-              periodSpecifier={periodSpecifier}
-              size="large"
-            />
-          </LearningPeriodTitle>
-        )}
-        <LearningPeriodTable>
-          <TBody>
-            {tyyppi === "WORKPLACE" && ohjaaja && (
-              <tr>
-                <TH>
-                  <FormattedMessage
-                    id="opiskelusuunnitelma.tyopaikkaohjaajaTitle"
-                    defaultMessage="Työpaikkaohjaaja"
-                  />
-                </TH>
-                <TD>
-                  {ohjaaja.nimi}, {selite}
-                  <br />
-                  {ohjaaja.sahkoposti}
-                </TD>
-              </tr>
-            )}
-            {tyyppi === "WORKPLACE" && ohjaaja && (
-              <tr>
-                <TH>
-                  <FormattedMessage
-                    id="opiskelusuunnitelma.koulutuksenjarjestajanEdustajaTitle"
-                    defaultMessage="Koulutuksen järjestäjän edustaja"
-                  />
-                </TH>
-                <TD>
-                  {/*TODO EH-757 add organizerOrgansation here, see comment above*/}
-                  {organizerRepresentative}
-                </TD>
-              </tr>
-            )}
-            {tyotehtavat.length > 0 && (
-              <tr>
-                <TH>
-                  <FormattedMessage
-                    id="opiskelusuunnitelma.keskeisetTyotehtavatTitle"
-                    defaultMessage="Keskeiset työtehtävät"
-                  />
-                </TH>
-                <EmptyTD />
-              </tr>
-            )}
-          </TBody>
-        </LearningPeriodTable>
-        {tyotehtavat.length > 0 && (
-          <React.Fragment>
-            <HMediaQuery.MaxWidth breakpoint="Tablet">
-              <CustomSlider>
-                {tyotehtavat.map((tyotehtava, i) => {
-                  return <Slide key={i}>{tyotehtava}</Slide>
-                })}
-              </CustomSlider>
-            </HMediaQuery.MaxWidth>
-            <HMediaQuery.MaxWidth breakpoint="Tablet" notMatch>
-              <LearningPeriodTasks>
-                {tyotehtavat.map((tyotehtava, i) => {
-                  return <li key={i}>{tyotehtava}</li>
-                })}
-              </LearningPeriodTasks>
-            </HMediaQuery.MaxWidth>
-          </React.Fragment>
-        )}
-      </Container>
-    )
-  }
-}
-
 interface LearningPeriodTEMPProps {
   learningPeriodTEMP: OsaamisenHankkimistapa
-  competenceAcquiringMethods?: Array<OsaamisenHankkimistapa>
-  organizer?: JarjestajanEdustaja
 }
 
 export class LearningPeriodTEMP extends React.Component<
   LearningPeriodTEMPProps
 > {
   render() {
-    const {
-      learningPeriodTEMP,
-      // competenceAcquiringMethods,
-      organizer
-    } = this.props
+    const { learningPeriodTEMP } = this.props
     const {
       alku,
       loppu,

--- a/shared/components/StudyInfo/LearningPeriod.tsx
+++ b/shared/components/StudyInfo/LearningPeriod.tsx
@@ -165,3 +165,131 @@ export class LearningPeriod extends React.Component<LearningPeriodProps> {
     )
   }
 }
+
+interface LearningPeriodTEMPProps {
+  learningPeriodTEMP: OsaamisenHankkimistapa
+  competenceAcquiringMethods?: Array<OsaamisenHankkimistapa>
+  organizer?: JarjestajanEdustaja
+}
+
+export class LearningPeriodTEMP extends React.Component<
+  LearningPeriodTEMPProps
+> {
+  render() {
+    const {
+      learningPeriodTEMP
+      // competenceAcquiringMethods,
+      // organizer
+    } = this.props
+    const { alku, loppu, nimi } = learningPeriodTEMP
+
+    // const method = competenceAcquiringMethods
+    //   ? competenceAcquiringMethods[0]
+    //   : undefined
+    // const workplaceSelite =
+    //   tyyppi === "WORKPLACE" &&
+    //   method &&
+    //   method.tyopaikallaJarjestettavaKoulutus
+    //     ? selite +
+    //       ", " +
+    //       method.tyopaikallaJarjestettavaKoulutus.tyopaikanYTunnus
+    //     : selite
+    // const periodSpecifier =
+    //   method && method.ajanjaksonTarkenne ? method.ajanjaksonTarkenne : ""
+    // const organizerRepresentative =
+    //   organizer && organizer.nimi ? organizer.nimi : ""
+    // TODO EH-757, this need to be fixed. Comment out after competenceAqcquiringMethods have been removed and
+    // harjoittelujaksot replaced with osaamisenHankkimistapa
+    // const organizerOrganisation = organizer && organizer.oppilaitosNimi ? organizer.oppilaitosNimi : ""
+
+    return (
+      <Container data-testid="StudyInfo.LearningPeriod">
+        TESTIA {alku}, {loppu}, {nimi}
+        {/*{(alku || loppu) && (*/}
+        {/*  <LearningPeriodTitle>*/}
+        {/*    <LearningEvent*/}
+        {/*      title={*/}
+        {/*        tyyppi === "OTHER" ? (*/}
+        {/*          nimi*/}
+        {/*        ) : (*/}
+        {/*          <FormattedMessage*/}
+        {/*            id="opiskelusuunnitelma.tyossaoppiminenTitle"*/}
+        {/*            defaultMessage="Työpaikalla oppiminen"*/}
+        {/*          />*/}
+        {/*        )*/}
+        {/*      }*/}
+        {/*      type={tyyppi}*/}
+        {/*      description={tyyppi === "WORKPLACE" ? workplaceSelite : selite}*/}
+        {/*      startDate={alku}*/}
+        {/*      endDate={loppu}*/}
+        {/*      periodSpecifier={periodSpecifier}*/}
+        {/*      size="large"*/}
+        {/*    />*/}
+        {/*  </LearningPeriodTitle>*/}
+        {/*)}*/}
+        {/*<LearningPeriodTable>*/}
+        {/*  <TBody>*/}
+        {/*    {tyyppi === "WORKPLACE" && ohjaaja && (*/}
+        {/*      <tr>*/}
+        {/*        <TH>*/}
+        {/*          <FormattedMessage*/}
+        {/*            id="opiskelusuunnitelma.tyopaikkaohjaajaTitle"*/}
+        {/*            defaultMessage="Työpaikkaohjaaja"*/}
+        {/*          />*/}
+        {/*        </TH>*/}
+        {/*        <TD>*/}
+        {/*          {ohjaaja.nimi}, {selite}*/}
+        {/*          <br />*/}
+        {/*          {ohjaaja.sahkoposti}*/}
+        {/*        </TD>*/}
+        {/*      </tr>*/}
+        {/*    )}*/}
+        {/*    {tyyppi === "WORKPLACE" && ohjaaja && (*/}
+        {/*      <tr>*/}
+        {/*        <TH>*/}
+        {/*          <FormattedMessage*/}
+        {/*            id="opiskelusuunnitelma.koulutuksenjarjestajanEdustajaTitle"*/}
+        {/*            defaultMessage="Koulutuksen järjestäjän edustaja"*/}
+        {/*          />*/}
+        {/*        </TH>*/}
+        {/*        <TD>*/}
+        {/*          /!*TODO EH-757 add organizerOrgansation here, see comment above*!/*/}
+        {/*          {organizerRepresentative}*/}
+        {/*        </TD>*/}
+        {/*      </tr>*/}
+        {/*    )}*/}
+        {/*    {tyotehtavat.length > 0 && (*/}
+        {/*      <tr>*/}
+        {/*        <TH>*/}
+        {/*          <FormattedMessage*/}
+        {/*            id="opiskelusuunnitelma.keskeisetTyotehtavatTitle"*/}
+        {/*            defaultMessage="Keskeiset työtehtävät"*/}
+        {/*          />*/}
+        {/*        </TH>*/}
+        {/*        <EmptyTD />*/}
+        {/*      </tr>*/}
+        {/*    )}*/}
+        {/*  </TBody>*/}
+        {/*</LearningPeriodTable>*/}
+        {/*{tyotehtavat.length > 0 && (*/}
+        {/*  <React.Fragment>*/}
+        {/*    <HMediaQuery.MaxWidth breakpoint="Tablet">*/}
+        {/*      <CustomSlider>*/}
+        {/*        {tyotehtavat.map((tyotehtava, i) => {*/}
+        {/*          return <Slide key={i}>{tyotehtava}</Slide>*/}
+        {/*        })}*/}
+        {/*      </CustomSlider>*/}
+        {/*    </HMediaQuery.MaxWidth>*/}
+        {/*    <HMediaQuery.MaxWidth breakpoint="Tablet" notMatch>*/}
+        {/*      <LearningPeriodTasks>*/}
+        {/*        {tyotehtavat.map((tyotehtava, i) => {*/}
+        {/*          return <li key={i}>{tyotehtava}</li>*/}
+        {/*        })}*/}
+        {/*      </LearningPeriodTasks>*/}
+        {/*    </HMediaQuery.MaxWidth>*/}
+        {/*  </React.Fragment>*/}
+        {/*)}*/}
+      </Container>
+    )
+  }
+}

--- a/shared/components/StudyInfo/LearningPeriod.tsx
+++ b/shared/components/StudyInfo/LearningPeriod.tsx
@@ -195,6 +195,9 @@ export class LearningPeriodTEMP extends React.Component<
     const vastuullinenTyopaikkaOhjaaja =
       tyopaikallaJarjestettavaKoulutus?.vastuullinenTyopaikkaOhjaaja
 
+    const keskeisetTyotehtavat =
+      tyopaikallaJarjestettavaKoulutus?.keskeisetTyotehtavat
+
     const workplaceSelite =
       tyyppi === "WORKPLACE" && tyopaikallaJarjestettavaKoulutus
         ? selite + ", " + tyopaikallaJarjestettavaKoulutus.tyopaikanYTunnus
@@ -252,37 +255,37 @@ export class LearningPeriodTEMP extends React.Component<
                 <TD>{jarjestajanEdustaja.oppilaitosHenkiloDescription}</TD>
               </tr>
             )}
-            {/*{tyotehtavat.length > 0 && (*/}
-            {/*  <tr>*/}
-            {/*    <TH>*/}
-            {/*      <FormattedMessage*/}
-            {/*        id="opiskelusuunnitelma.keskeisetTyotehtavatTitle"*/}
-            {/*        defaultMessage="Keskeiset työtehtävät"*/}
-            {/*      />*/}
-            {/*    </TH>*/}
-            {/*    <EmptyTD />*/}
-            {/*  </tr>*/}
-            {/*)}*/}
+            {keskeisetTyotehtavat.length > 0 && (
+              <tr>
+                <TH>
+                  <FormattedMessage
+                    id="opiskelusuunnitelma.keskeisetTyotehtavatTitle"
+                    defaultMessage="Keskeiset työtehtävät"
+                  />
+                </TH>
+                <EmptyTD />
+              </tr>
+            )}
           </TBody>
         </LearningPeriodTable>
-        {/*{tyotehtavat.length > 0 && (*/}
-        {/*  <React.Fragment>*/}
-        {/*    <HMediaQuery.MaxWidth breakpoint="Tablet">*/}
-        {/*      <CustomSlider>*/}
-        {/*        {tyotehtavat.map((tyotehtava, i) => {*/}
-        {/*          return <Slide key={i}>{tyotehtava}</Slide>*/}
-        {/*        })}*/}
-        {/*      </CustomSlider>*/}
-        {/*    </HMediaQuery.MaxWidth>*/}
-        {/*    <HMediaQuery.MaxWidth breakpoint="Tablet" notMatch>*/}
-        {/*      <LearningPeriodTasks>*/}
-        {/*        {tyotehtavat.map((tyotehtava, i) => {*/}
-        {/*          return <li key={i}>{tyotehtava}</li>*/}
-        {/*        })}*/}
-        {/*      </LearningPeriodTasks>*/}
-        {/*    </HMediaQuery.MaxWidth>*/}
-        {/*  </React.Fragment>*/}
-        {/*)}*/}
+        {keskeisetTyotehtavat.length > 0 && (
+          <React.Fragment>
+            <HMediaQuery.MaxWidth breakpoint="Tablet">
+              <CustomSlider>
+                {keskeisetTyotehtavat.map((tyotehtava, i) => {
+                  return <Slide key={i}>{tyotehtava}</Slide>
+                })}
+              </CustomSlider>
+            </HMediaQuery.MaxWidth>
+            <HMediaQuery.MaxWidth breakpoint="Tablet" notMatch>
+              <LearningPeriodTasks>
+                {keskeisetTyotehtavat.map((tyotehtava, i) => {
+                  return <li key={i}>{tyotehtava}</li>
+                })}
+              </LearningPeriodTasks>
+            </HMediaQuery.MaxWidth>
+          </React.Fragment>
+        )}
       </Container>
     )
   }

--- a/shared/components/__tests__/StudyInfo.test.tsx
+++ b/shared/components/__tests__/StudyInfo.test.tsx
@@ -2,7 +2,7 @@ import React from "react"
 import { render, fireEvent, wait } from "@testing-library/react"
 import { StudyInfo } from "../StudyInfo"
 import { renderWithContext } from "testUtils"
-import { Naytto, Harjoittelujakso } from "models/helpers/TutkinnonOsa"
+import { Naytto, OsaamisenHankkimistapa } from "models/helpers/TutkinnonOsa"
 import { mockFetch } from "fetchUtils"
 import { OsaamisenHankkimistapaType } from "../../models/OsaamisenHankkimistapa"
 
@@ -80,32 +80,40 @@ const naytot3 = [
   }
 ]
 
-const harjoittelujaksot1 = [
+const osaamisenHankkimistapa1 = [
   {
     alku: "2019-05-24",
     loppu: "2019-07-31",
     nimi: "Verkko-oppiminen",
     selite: "Moodle-kurssi, viestintä",
-    tyyppi: OsaamisenHankkimistapaType.Other as Harjoittelujakso["tyyppi"]
-  }
+    tyyppi: OsaamisenHankkimistapaType.Other
+  } as OsaamisenHankkimistapa
 ]
 
-const harjoittelujaksot2 = [
+const osaamisenHankkimistapa2 = [
   {
     alku: "2019-09-13",
     loppu: "2019-09-30",
-    ohjaaja: { nimi: "John McAfee", sahkoposti: "john@mock.dev" },
-    tyotehtavat: ["Elintarvikkeiden valmistus", "Elintarvikkeiden säilytys"],
+    tyopaikallaJarjestettavaKoulutus: {
+      vastuullinenTyopaikkaOhjaaja: {
+        nimi: "John McAfee",
+        sahkoposti: "john@mock.dev"
+      },
+      keskeisetTyotehtavat: [
+        "Elintarvikkeiden valmistus",
+        "Elintarvikkeiden säilytys"
+      ]
+    },
     selite: "Palvelutalo Koivikkola",
-    tyyppi: OsaamisenHankkimistapaType.Workplace as Harjoittelujakso["tyyppi"]
-  },
+    tyyppi: OsaamisenHankkimistapaType.Workplace
+  } as OsaamisenHankkimistapa,
   {
     alku: "2019-10-01",
     loppu: "2019-10-15",
     nimi: "Verkko-oppiminen",
     selite: "Moodle-kurssi, Ikääntyminen",
-    tyyppi: OsaamisenHankkimistapaType.Other as Harjoittelujakso["tyyppi"]
-  }
+    tyyppi: OsaamisenHankkimistapaType.Other
+  } as OsaamisenHankkimistapa
 ]
 
 describe("StudyInfo", () => {
@@ -191,14 +199,16 @@ describe("StudyInfo", () => {
       queryByTestId,
       rerender
     } = renderWithContext(
-      <StudyInfo title="Test" learningPeriods={harjoittelujaksot1} />
+      <StudyInfo title="Test" learningPeriodsTEMP={osaamisenHankkimistapa1} />
     )
 
     expect(getByTestId("StudyInfo.DetailsCollapsed")).toBeInTheDocument()
     expect(queryByTestId("StudyInfo.DetailsExpanded")).not.toBeInTheDocument()
     expect(getAllByTestId("StudyInfo.LearningEvent").length).toBe(1)
 
-    rerender(<StudyInfo title="Test" learningPeriods={harjoittelujaksot2} />)
+    rerender(
+      <StudyInfo title="Test" learningPeriodsTEMP={osaamisenHankkimistapa2} />
+    )
 
     await wait(() => {
       expect(getAllByTestId("StudyInfo.LearningEvent").length).toBe(2)

--- a/shared/components/__tests__/StudyInfo.test.tsx
+++ b/shared/components/__tests__/StudyInfo.test.tsx
@@ -4,6 +4,7 @@ import { StudyInfo } from "../StudyInfo"
 import { renderWithContext } from "testUtils"
 import { Naytto, Harjoittelujakso } from "models/helpers/TutkinnonOsa"
 import { mockFetch } from "fetchUtils"
+import { OsaamisenHankkimistapaType } from "../../models/OsaamisenHankkimistapa"
 
 const osaamisvaatimukset = [
   {
@@ -85,7 +86,7 @@ const harjoittelujaksot1 = [
     loppu: "2019-07-31",
     nimi: "Verkko-oppiminen",
     selite: "Moodle-kurssi, viestintä",
-    tyyppi: "OTHER" as Harjoittelujakso["tyyppi"]
+    tyyppi: OsaamisenHankkimistapaType.Other as Harjoittelujakso["tyyppi"]
   }
 ]
 
@@ -96,14 +97,14 @@ const harjoittelujaksot2 = [
     ohjaaja: { nimi: "John McAfee", sahkoposti: "john@mock.dev" },
     tyotehtavat: ["Elintarvikkeiden valmistus", "Elintarvikkeiden säilytys"],
     selite: "Palvelutalo Koivikkola",
-    tyyppi: "WORKPLACE" as Harjoittelujakso["tyyppi"]
+    tyyppi: OsaamisenHankkimistapaType.Workplace as Harjoittelujakso["tyyppi"]
   },
   {
     alku: "2019-10-01",
     loppu: "2019-10-15",
     nimi: "Verkko-oppiminen",
     selite: "Moodle-kurssi, Ikääntyminen",
-    tyyppi: "OTHER" as Harjoittelujakso["tyyppi"]
+    tyyppi: OsaamisenHankkimistapaType.Other as Harjoittelujakso["tyyppi"]
   }
 ]
 

--- a/shared/models/Oppilaitoshenkilo.ts
+++ b/shared/models/Oppilaitoshenkilo.ts
@@ -31,6 +31,11 @@ export const Oppilaitoshenkilo = types
           self.oppilaitos.nimi[root.translations.activeLocale]
           ? self.oppilaitos.nimi[root.translations.activeLocale]
           : ""
+      },
+      get oppilaitosHenkiloDescription() {
+        return (
+          self.nimi + (self.oppilaitosNimi ? ", " + self.oppilatosNimi : "")
+        )
       }
     }
   })

--- a/shared/models/Oppilaitoshenkilo.ts
+++ b/shared/models/Oppilaitoshenkilo.ts
@@ -34,7 +34,7 @@ export const Oppilaitoshenkilo = types
       },
       get oppilaitosHenkiloDescription() {
         return (
-          self.nimi + (self.oppilaitosNimi ? ", " + self.oppilatosNimi : "")
+          self.nimi + (self.oppilaitosNimi ? ", " + self.oppilaitosNimi : "")
         )
       }
     }

--- a/shared/models/OsaamisenHankkimistapa.ts
+++ b/shared/models/OsaamisenHankkimistapa.ts
@@ -21,8 +21,15 @@ const Model = types.model("OsaamisenHankkimistapaModel", {
   loppu: types.optional(types.string, "")
 })
 
-export const OsaamisenHankkimistapa = types.compose(
-  "OsaamisenHankkimistapa",
-  EnrichKoodiUri,
-  Model
-)
+export const OsaamisenHankkimistapa = types
+  .compose("OsaamisenHankkimistapa", EnrichKoodiUri, Model)
+  .views(self => {
+    return {
+      get nimi() {
+        return self.muutOppimisymparistot.length > 0 &&
+          self.muutOppimisymparistot[0].oppimisymparisto
+          ? self.muutOppimisymparistot[0].oppimisymparisto.nimi
+          : ""
+      }
+    }
+  })

--- a/shared/models/OsaamisenHankkimistapa.ts
+++ b/shared/models/OsaamisenHankkimistapa.ts
@@ -36,6 +36,14 @@ export const OsaamisenHankkimistapa = types
           ? self.muutOppimisymparistot[0].selite
           : self.tyopaikallaJarjestettavaKoulutus.tyopaikanNimi
       },
+      get workplaceSelite() {
+        return self.tyyppi === "WORKPLACE" &&
+          self.tyopaikallaJarjestettavaKoulutus
+          ? self.selite +
+              ", " +
+              self.tyopaikallaJarjestettavaKoulutus.tyopaikanYTunnus
+          : self.selite
+      },
       get tyyppi() {
         return self.osaamisenHankkimistapaKoodiUri.includes(
           "koulutussopimus"

--- a/shared/models/OsaamisenHankkimistapa.ts
+++ b/shared/models/OsaamisenHankkimistapa.ts
@@ -42,19 +42,21 @@ export const OsaamisenHankkimistapa = types
           : self.tyopaikallaJarjestettavaKoulutus.tyopaikanNimi
       },
       get workplaceSelite() {
-        return self.tyyppi === "WORKPLACE" &&
+        return self.tyyppi === OsaamisenHankkimistapaType.Workplace &&
           self.tyopaikallaJarjestettavaKoulutus
           ? self.selite +
               ", " +
               self.tyopaikallaJarjestettavaKoulutus.tyopaikanYTunnus
           : self.selite
       },
-      get tyyppi() {
+      get tyyppi():
+        | OsaamisenHankkimistapaType.Workplace
+        | OsaamisenHankkimistapaType.Other {
         return self.osaamisenHankkimistapaKoodiUri.includes(
           "koulutussopimus"
         ) || self.osaamisenHankkimistapaKoodiUri.includes("oppisopimus")
-          ? "WORKPLACE"
-          : "OTHER"
+          ? OsaamisenHankkimistapaType.Workplace
+          : OsaamisenHankkimistapaType.Other
       }
     }
   })

--- a/shared/models/OsaamisenHankkimistapa.ts
+++ b/shared/models/OsaamisenHankkimistapa.ts
@@ -30,6 +30,18 @@ export const OsaamisenHankkimistapa = types
           self.muutOppimisymparistot[0].oppimisymparisto
           ? self.muutOppimisymparistot[0].oppimisymparisto.nimi
           : ""
+      },
+      get selite() {
+        return self.muutOppimisymparistot.length > 0
+          ? self.muutOppimisymparistot[0].selite
+          : self.tyopaikallaJarjestettavaKoulutus.tyopaikanNimi
+      },
+      get tyyppi() {
+        return self.osaamisenHankkimistapaKoodiUri.includes(
+          "koulutussopimus"
+        ) || self.osaamisenHankkimistapaKoodiUri.includes("oppisopimus")
+          ? "WORKPLACE"
+          : "OTHER"
       }
     }
   })

--- a/shared/models/OsaamisenHankkimistapa.ts
+++ b/shared/models/OsaamisenHankkimistapa.ts
@@ -5,6 +5,11 @@ import { MuuOppimisymparisto } from "./MuuOppimisymparisto"
 import { EnrichKoodiUri } from "models/EnrichKoodiUri"
 import { KoodistoVastaus } from "models/KoodistoVastaus"
 
+export enum OsaamisenHankkimistapaType {
+  Workplace = "WORKPLACE",
+  Other = "OTHER"
+}
+
 const Model = types.model("OsaamisenHankkimistapaModel", {
   id: types.optional(types.number, 0),
   hankkijanEdustaja: types.optional(Oppilaitoshenkilo, {}),

--- a/shared/models/helpers/HankittavatTutkinnonOsatViews.ts
+++ b/shared/models/helpers/HankittavatTutkinnonOsatViews.ts
@@ -8,6 +8,7 @@ import { LocaleRoot } from "models/helpers/LocaleRoot"
 import { getOsaamispisteet } from "./getOsaamispisteet"
 import { ShareType } from "stores/NotificationStore"
 import find from "lodash.find"
+import { OsaamisenHankkimistapaType } from "../OsaamisenHankkimistapa"
 
 // TODO: type tutkinnonOsa
 export const HankittavatTutkinnonOsatViews = types
@@ -47,7 +48,10 @@ export const HankittavatTutkinnonOsatViews = types
         const typeMatch =
           type === "naytto"
             ? this.naytot.length > 0
-            : !!find(this.harjoittelujaksot, hj => hj.tyyppi === "WORKPLACE")
+            : !!find(
+                this.harjoittelujaksot,
+                hj => hj.tyyppi === OsaamisenHankkimistapaType.Workplace
+              )
         return koodiUriMatch && typeMatch
       }
     }

--- a/shared/models/helpers/TutkinnonOsa.ts
+++ b/shared/models/helpers/TutkinnonOsa.ts
@@ -1,6 +1,7 @@
 import { ShareType } from "stores/NotificationStore"
 import { Instance } from "mobx-state-tree"
 import { OsaamisenHankkimistapa } from "../OsaamisenHankkimistapa"
+import { Oppilaitoshenkilo } from "../Oppilaitoshenkilo"
 
 interface Arviointikriteeri {
   kuvaus?: string
@@ -26,11 +27,8 @@ export interface MuuOppimisymparisto {
   oppimisymparisto?: Oppimisymparisto
 }
 
-export interface JarjestajanEdustaja {
-  nimi?: string
-  oppilaitosOid?: string
-  oppilaitosNimi?: string
-}
+export interface JarjestajanEdustaja
+  extends Instance<typeof Oppilaitoshenkilo> {}
 
 export interface OsaamisenHankkimistapa
   extends Instance<typeof OsaamisenHankkimistapa> {}

--- a/shared/models/helpers/TutkinnonOsa.ts
+++ b/shared/models/helpers/TutkinnonOsa.ts
@@ -1,4 +1,6 @@
 import { ShareType } from "stores/NotificationStore"
+import { Instance } from "mobx-state-tree"
+import { OsaamisenHankkimistapa } from "../OsaamisenHankkimistapa"
 
 interface Arviointikriteeri {
   kuvaus?: string
@@ -29,16 +31,9 @@ export interface JarjestajanEdustaja {
   oppilaitosOid?: string
   oppilaitosNimi?: string
 }
-export interface OsaamisenHankkimistapa {
-  tyopaikallaJarjestettavaKoulutus?: { tyopaikanYTunnus: string }
-  osaamisenHankkimistapaKoodiUri?: string
-  ajanjaksonTarkenne?: string
-  jarjestajanEdustaja?: JarjestajanEdustaja
-  muutOppimisymparistot?: MuuOppimisymparisto[]
-  alku: string
-  loppu: string
-  nimi: string
-}
+
+export interface OsaamisenHankkimistapa
+  extends Instance<typeof OsaamisenHankkimistapa> {}
 
 export interface Nayttoymparisto {
   nimi: string

--- a/shared/models/helpers/TutkinnonOsa.ts
+++ b/shared/models/helpers/TutkinnonOsa.ts
@@ -37,6 +37,7 @@ export interface OsaamisenHankkimistapa {
   muutOppimisymparistot?: MuuOppimisymparisto[]
   alku: string
   loppu: string
+  nimi: string
 }
 
 export interface Nayttoymparisto {


### PR DESCRIPTION
OsaamisenHankkimistapa was previously converted to HarjoitteJaksot which caused confusion as Harjoittelujaksot isn't domain concept. Moved functionality from getHarjoittelujaksot to OsaamisenHankkimistapa and made components take array of OsaamisenHankkimistapa as a prop instead of Harjoittelujaksot array. Added temporary structures so that Harjoittelujaksot can be refactored away gradually. Those temp structures and harjoitteluJaksot will be deleted or renamed in a upcoming PR as this PR is already too big and needs to be integrated asap.