### PR TITLE
Manual UI reorder

### DIFF
--- a/virkailija/src/routes/LuoHOKS/uiSchema.ts
+++ b/virkailija/src/routes/LuoHOKS/uiSchema.ts
@@ -879,6 +879,7 @@ const fullUiSchema = (options: UiSchemaOptions): { [key: string]: any } => ({
         items: {
           "ui:order": [
             "osa-alue-koodi-uri",
+            "koulutuksen-jarjestaja-oid",
             "osa-alue-koodi-versio",
             "vaatimuksista-tai-tavoitteista-poikkeaminen",
             "olennainen-seikka",

--- a/virkailija/src/routes/MuokkaaHOKS/uiSchema.ts
+++ b/virkailija/src/routes/MuokkaaHOKS/uiSchema.ts
@@ -872,6 +872,7 @@ const fullUiSchema = (options: UiSchemaOptions): { [key: string]: any } => ({
         items: {
           "ui:order": [
             "osa-alue-koodi-uri",
+            "koulutuksen-jarjestaja-oid",
             "osa-alue-koodi-versio",
             "vaatimuksista-tai-tavoitteista-poikkeaminen",
             "olennainen-seikka",


### PR DESCRIPTION
Moved koulutuksen-jarjestaja-oid under osa-alue-koodi-uri from the bottom of the form that was the default position.