### PR TITLE
ADRs introduced

### DIFF
--- a/doc/adr/0001-record-architecture-and-desing-decisions.md
+++ b/doc/adr/0001-record-architecture-and-desing-decisions.md
@@ -1,0 +1,23 @@
+# 1. Record architecture and desing decisions
+
+Date: 26.03.2020
+
+## Status
+
+Accepted
+
+## Context
+
+We need to record the architectural and desing decisions made during this project.
+
+## Decision
+
+We will use Architecture Decision Records, as described by
+Michael Nygard in this article: http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions
+
+Also https://medium.com/better-programming/here-is-a-simple-yet-powerful-tool-to-record-your-architectural-decisions-5fb31367a7da
+
+## Consequences
+
+Able to see motivation and history of architecture and desing decision and hopefully
+provide context why some things are the way they are.

--- a/doc/adr/0002-use-finnish-as-the-domain-language.md
+++ b/doc/adr/0002-use-finnish-as-the-domain-language.md
@@ -33,9 +33,9 @@ interface LearningEventProps {
 }
 ```
 
-className, title, size, description, startDate, endDate are techincal or generic words and should be in English.
+className, title, size, description, startDate, endDate are technical or generic words and should be in English.
 Demonstration and demonstrationEnvironment are domain and datamodel words naytto and nayttoYmparisto and should be in
-Finnish. PeriodSpecifier is straight from the data model thus should be ajanjaksonTarkenne. LearningEvent is used for
+Finnish. PeriodSpecifier is straight from the data model and thus should be ajanjaksonTarkenne. LearningEvent is used for
 both osaamisenHankkiminen and osaamisenOsoittaminen and there isn't domain word to describe these both so learningEvent
 should stay as is, although probably best option would be to split learningEvent component to OsaamisenHankkiminen and
 OsaamisenOsoittaminen components.
@@ -58,5 +58,5 @@ interface LearningEventProps {
 
 ## Consequences
 
-Translation causes confusion and misunderstandings. It's clearer when one ubiquitous language for domain is used when
-talking to domain experts and in coding.
+Translation causes confusion and misunderstandings. It's clearer when one ubiquitous language for domain is used in
+coding and when talking to domain experts.

--- a/doc/adr/0002-use-finnish-as-the-domain-language.md
+++ b/doc/adr/0002-use-finnish-as-the-domain-language.md
@@ -1,0 +1,62 @@
+# 1. Use Finnish as the domain language
+
+Date: 26.03.2020
+
+## Status
+
+Accepted
+
+## Context
+
+There are currently mixed conventions of translating domain words. For example mobx-state-tree-model properties are
+in Finnish but react component props in English even though data might be exactly same.
+
+## Decision
+
+We will use Finnish as the domain language (e.g. osaamisenHankkimistapa, koulutuksenJarjestaja) and English when
+the word is not directly related to eHOKS domain. Words are refactored gradually so there might exist mixed
+conventions quite some time.
+
+Here is one expample:
+
+```typescript
+interface LearningEventProps {
+  className?: string
+  title?: React.ReactNode
+  isDemonstration?: boolean
+  size?: "small" | "large"
+  description?: string
+  startDate?: string
+  endDate?: string
+  periodSpecifier?: string
+  demonstrationEnviromentDescription?: string
+}
+```
+
+className, title, size, description, startDate, endDate are techincal or generic words and should be in English.
+Demonstration and demonstrationEnvironment are domain and datamodel words naytto and nayttoYmparisto and should be in
+Finnish. PeriodSpecifier is straight from the data model thus should be ajanjaksonTarkenne. LearningEvent is used for
+both osaamisenHankkiminen and osaamisenOsoittaminen and there isn't domain word to describe these both so learningEvent
+should stay as is, although probably best option would be to split learningEvent component to OsaamisenHankkiminen and
+OsaamisenOsoittaminen components.
+
+Example fixed:
+
+```typescript
+interface LearningEventProps {
+  className?: string
+  title?: React.ReactNode
+  isNaytto?: boolean
+  size?: "small" | "large"
+  description?: string
+  startDate?: string
+  endDate?: string
+  ajanjaksonTarkenne?: string
+  nayttoYmparistoDescription?: string
+}
+```
+
+## Consequences
+
+Translation causes confusion and misunderstandings. It's clearer when one ubiquitous language for domain is used when
+talking to domain experts and in coding.

--- a/doc/adr/0002-use-finnish-as-the-domain-language.md
+++ b/doc/adr/0002-use-finnish-as-the-domain-language.md
@@ -9,7 +9,7 @@ Accepted
 ## Context
 
 There are currently mixed conventions of translating domain words. For example mobx-state-tree-model properties are
-in Finnish but react component props in English even though data might be exactly same.
+in Finnish but react component props in English even though data might be exactly the same.
 
 ## Decision
 

--- a/doc/adr/0002-use-finnish-as-the-domain-language.md
+++ b/doc/adr/0002-use-finnish-as-the-domain-language.md
@@ -1,4 +1,4 @@
-# 1. Use Finnish as the domain language
+# 2. Use Finnish as the domain language
 
 Date: 26.03.2020
 


### PR DESCRIPTION
Template to record architectural decisions. Added decision record to use Finnish as the domain language.

https://medium.com/better-programming/here-is-a-simple-yet-powerful-tool-to-record-your-architectural-decisions-5fb31367a7da
http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions