### PR TITLE
Eh 896 redefine eslint rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -14,9 +14,15 @@ module.exports = {
   },
   plugins: ["@typescript-eslint", "prefer-arrow"],
   extends: [
+    "plugin:react/recommended", // Uses the recommended rules from @eslint-plugin-react
     "prettier/@typescript-eslint", // Uses eslint-config-prettier to disable ESLint rules from @typescript-eslint/eslint-plugin that would conflict with prettier
     "plugin:prettier/recommended" // Enables eslint-plugin-prettier and eslint-config-prettier. This will display prettier errors as ESLint errors. Make sure this is always the last configuration in the extends array.
   ],
+  settings: {
+    react: {
+      version: "detect"
+    }
+  },
   rules: {
     "@typescript-eslint/adjacent-overload-signatures": "error",
     "@typescript-eslint/array-type": "error",

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -15,6 +15,7 @@ module.exports = {
   plugins: ["@typescript-eslint", "prefer-arrow"],
   extends: [
     "plugin:react/recommended", // Uses the recommended rules from @eslint-plugin-react
+    "plugin:@typescript-eslint/recommended", // Uses the recommended rules from the @typescript-eslint/eslint-plugin
     "prettier/@typescript-eslint", // Uses eslint-config-prettier to disable ESLint rules from @typescript-eslint/eslint-plugin that would conflict with prettier
     "plugin:prettier/recommended" // Enables eslint-plugin-prettier and eslint-config-prettier. This will display prettier errors as ESLint errors. Make sure this is always the last configuration in the extends array.
   ],
@@ -24,6 +25,10 @@ module.exports = {
     }
   },
   rules: {
+    "@typescript-eslint/explicit-function-return-type": "warn", // TODO
+    "@typescript-eslint/ban-ts-ignore": "off",
+    "@typescript-eslint/ban-ts-comment": "warn", // TODO
+    "@typescript-eslint/no-non-null-assertion": "warn", // TODO
     "@typescript-eslint/adjacent-overload-signatures": "error",
     "@typescript-eslint/array-type": "error",
     "@typescript-eslint/ban-types": "error",

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -25,10 +25,11 @@ module.exports = {
     }
   },
   rules: {
-    "@typescript-eslint/explicit-function-return-type": "warn", // TODO
+    "@typescript-eslint/explicit-function-return-type": "off",
     "@typescript-eslint/ban-ts-ignore": "off",
-    "@typescript-eslint/ban-ts-comment": "warn", // TODO
-    "@typescript-eslint/no-non-null-assertion": "warn", // TODO
+    "@typescript-eslint/ban-ts-comment": "warn",
+    "@typescript-eslint/no-non-null-assertion": "off",
+    "no-unused-vars": "off",
     "@typescript-eslint/no-unused-vars": ["error", { argsIgnorePattern: "^_" }],
     "@typescript-eslint/adjacent-overload-signatures": "error",
     "@typescript-eslint/array-type": "error",

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -29,6 +29,7 @@ module.exports = {
     "@typescript-eslint/ban-ts-ignore": "off",
     "@typescript-eslint/ban-ts-comment": "warn", // TODO
     "@typescript-eslint/no-non-null-assertion": "warn", // TODO
+    "@typescript-eslint/no-unused-vars": ["error", { argsIgnorePattern: "^_" }],
     "@typescript-eslint/adjacent-overload-signatures": "error",
     "@typescript-eslint/array-type": "error",
     "@typescript-eslint/ban-types": "error",

--- a/oppija/src/routes/App.tsx
+++ b/oppija/src/routes/App.tsx
@@ -1,4 +1,4 @@
-import { Router } from "@reach/router"
+import { Router, RouteComponentProps } from "@reach/router"
 import { ThemeWrapper } from "components/ThemeWrapper"
 import {
   cleanLocaleParam,
@@ -34,7 +34,7 @@ const Main = styled("main")``
 
 const ModalContainer = styled("div")``
 
-const MainApp = () => (
+const MainApp = (_: RouteComponentProps) => (
   <Container>
     <AppHeader />
     <AppNotifications />

--- a/oppija/src/routes/App.tsx
+++ b/oppija/src/routes/App.tsx
@@ -34,7 +34,7 @@ const Main = styled("main")``
 
 const ModalContainer = styled("div")``
 
-const MainApp = (_: { path: string }) => (
+const MainApp = () => (
   <Container>
     <AppHeader />
     <AppNotifications />

--- a/oppija/src/routes/App/MobileMenu.tsx
+++ b/oppija/src/routes/App/MobileMenu.tsx
@@ -83,7 +83,7 @@ export const MobileMenu: React.FunctionComponent<MobileMenuProps> = ({
   toggleMenu,
   logout,
   session
-}) => {
+}: MobileMenuProps) => {
   const ref = React.useRef(null)
   useOnClickOutside(ref, toggleMenu)
 

--- a/oppija/src/routes/Saavutettavuusseloste.tsx
+++ b/oppija/src/routes/Saavutettavuusseloste.tsx
@@ -1,4 +1,3 @@
-import { RouteComponentProps } from "@reach/router"
 import { Container } from "components/Container"
 import React from "react"
 import { FormattedMessage } from "react-intl"
@@ -12,9 +11,7 @@ const Content = styled("div")`
   }
 `
 
-type SaavutettavuusselosteProps = RouteComponentProps
-
-export const Saavutettavuusseloste = (_: SaavutettavuusselosteProps) => (
+export const Saavutettavuusseloste = () => (
   <Container>
     <Content>
       <h1>

--- a/oppija/src/routes/Saavutettavuusseloste.tsx
+++ b/oppija/src/routes/Saavutettavuusseloste.tsx
@@ -1,3 +1,4 @@
+import { RouteComponentProps } from "@reach/router"
 import { Container } from "components/Container"
 import React from "react"
 import { FormattedMessage } from "react-intl"
@@ -11,7 +12,7 @@ const Content = styled("div")`
   }
 `
 
-export const Saavutettavuusseloste = () => (
+export const Saavutettavuusseloste = (_: RouteComponentProps) => (
   <Container>
     <Content>
       <h1>

--- a/package-lock.json
+++ b/package-lock.json
@@ -2683,21 +2683,99 @@
       "integrity": "sha512-wBlsw+8n21e6eTd4yVv8YD/E3xq0O6nNnJIquutAsFGE7EyMKz7W6RNT6BRu1SmdgmlCZ9tb0X+j+D6HGr8pZw=="
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "2.27.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.27.0.tgz",
-      "integrity": "sha512-/my+vVHRN7zYgcp0n4z5A6HAK7bvKGBiswaM5zIlOQczsxj/aiD7RcgD+dvVFuwFaGh5+kM7XA6Q6PN0bvb1tw==",
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.28.0.tgz",
+      "integrity": "sha512-w0Ugcq2iatloEabQP56BRWJowliXUP5Wv6f9fKzjJmDW81hOTBxRoJ4LoEOxRpz9gcY51Libytd2ba3yLmSOfg==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/experimental-utils": "2.27.0",
+        "@typescript-eslint/experimental-utils": "2.28.0",
         "functional-red-black-tree": "^1.0.1",
         "regexpp": "^3.0.0",
         "tsutils": "^3.17.1"
       },
       "dependencies": {
+        "@typescript-eslint/experimental-utils": {
+          "version": "2.28.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.28.0.tgz",
+          "integrity": "sha512-4SL9OWjvFbHumM/Zh/ZeEjUFxrYKtdCi7At4GyKTbQlrj1HcphIDXlje4Uu4cY+qzszR5NdVin4CCm6AXCjd6w==",
+          "dev": true,
+          "requires": {
+            "@types/json-schema": "^7.0.3",
+            "@typescript-eslint/typescript-estree": "2.28.0",
+            "eslint-scope": "^5.0.0",
+            "eslint-utils": "^2.0.0"
+          }
+        },
+        "@typescript-eslint/typescript-estree": {
+          "version": "2.28.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.28.0.tgz",
+          "integrity": "sha512-HDr8MP9wfwkiuqzRVkuM3BeDrOC4cKbO5a6BymZBHUt5y/2pL0BXD6I/C/ceq2IZoHWhcASk+5/zo+dwgu9V8Q==",
+          "dev": true,
+          "requires": {
+            "debug": "^4.1.1",
+            "eslint-visitor-keys": "^1.1.0",
+            "glob": "^7.1.6",
+            "is-glob": "^4.0.1",
+            "lodash": "^4.17.15",
+            "semver": "^6.3.0",
+            "tsutils": "^3.17.1"
+          }
+        },
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "eslint-scope": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.0.0.tgz",
+          "integrity": "sha512-oYrhJW7S0bxAFDvWqzvMPRm6pcgcnWc4QnofCAqRTRfQC0JcwenzGglTtsLyIuuWFfkqDG9vz67cnttSd53djw==",
+          "dev": true,
+          "requires": {
+            "esrecurse": "^4.1.0",
+            "estraverse": "^4.1.1"
+          }
+        },
+        "glob": {
+          "version": "7.1.6",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+          "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        },
         "regexpp": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.1.0.tgz",
           "integrity": "sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==",
+          "dev": true
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
           "dev": true
         }
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -3250,6 +3250,17 @@
       "integrity": "sha512-hNfzcOV8W4NdualtqBFPyVO+54DSJuZGY9qT4pRroB6S9e3iiido2ISIC5h9R2sPJ8H3FHCIiEnsv1lPXO3KtQ==",
       "dev": true
     },
+    "array-includes": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.1.tgz",
+      "integrity": "sha512-c2VXaCHl7zPsvpkFsw4nxvFie4fh1ur9bpcgsVkIjqn0H/Xwdg+7fv3n2r/isyS8EBj5b06M9kHyZuIr4El6WQ==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.0",
+        "is-string": "^1.0.5"
+      }
+    },
     "array-map": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/array-map/-/array-map-0.0.0.tgz",
@@ -6099,6 +6110,60 @@
         "prettier-linter-helpers": "^1.0.0"
       }
     },
+    "eslint-plugin-react": {
+      "version": "7.19.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.19.0.tgz",
+      "integrity": "sha512-SPT8j72CGuAP+JFbT0sJHOB80TX/pu44gQ4vXH/cq+hQTiY2PuZ6IHkqXJV6x1b28GDdo1lbInjKUrrdUf0LOQ==",
+      "dev": true,
+      "requires": {
+        "array-includes": "^3.1.1",
+        "doctrine": "^2.1.0",
+        "has": "^1.0.3",
+        "jsx-ast-utils": "^2.2.3",
+        "object.entries": "^1.1.1",
+        "object.fromentries": "^2.0.2",
+        "object.values": "^1.1.1",
+        "prop-types": "^15.7.2",
+        "resolve": "^1.15.1",
+        "semver": "^6.3.0",
+        "string.prototype.matchall": "^4.0.2",
+        "xregexp": "^4.3.0"
+      },
+      "dependencies": {
+        "prop-types": {
+          "version": "15.7.2",
+          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+          "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+          "dev": true,
+          "requires": {
+            "loose-envify": "^1.4.0",
+            "object-assign": "^4.1.1",
+            "react-is": "^16.8.1"
+          }
+        },
+        "react-is": {
+          "version": "16.13.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+          "dev": true
+        },
+        "resolve": {
+          "version": "1.15.1",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.15.1.tgz",
+          "integrity": "sha512-84oo6ZTtoTUpjgNEr5SJyzQhzL72gaRodsSfyxC/AXRvwu0Yse9H8eF9IpGo7b8YetZhlI6v7ZQ6bKBFV/6S7w==",
+          "dev": true,
+          "requires": {
+            "path-parse": "^1.0.6"
+          }
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        }
+      }
+    },
     "eslint-scope": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.3.tgz",
@@ -8525,6 +8590,17 @@
         "ipaddr.js": "^1.9.0"
       }
     },
+    "internal-slot": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.2.tgz",
+      "integrity": "sha512-2cQNfwhAfJIkU4KZPkDI+Gj5yNNnbqi40W9Gge6dfnk4TocEVm00B3bdiL+JINrbGJil2TeHvM4rETGzk/f/0g==",
+      "dev": true,
+      "requires": {
+        "es-abstract": "^1.17.0-next.1",
+        "has": "^1.0.3",
+        "side-channel": "^1.0.2"
+      }
+    },
     "interpret": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.2.0.tgz",
@@ -8882,6 +8958,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+      "dev": true
+    },
+    "is-string": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.5.tgz",
+      "integrity": "sha512-buY6VNRjhQMiF1qWDouloZlQbRhDPCebwxSjxMjxgemYT46YMd2NR0/H+fBhEfWX4A/w9TBJ+ol+okqJKFE6vQ==",
       "dev": true
     },
     "is-symbol": {
@@ -11838,6 +11920,16 @@
         "warning": "^3.0.0"
       }
     },
+    "jsx-ast-utils": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-2.2.3.tgz",
+      "integrity": "sha512-EdIHFMm+1BPynpKOpdPqiOsvnIrInRGJD7bzPZdPkjitQEqpdpUuFpq4T0npZFKTiB3RhWFdGN+oqOJIdhDhQA==",
+      "dev": true,
+      "requires": {
+        "array-includes": "^3.0.3",
+        "object.assign": "^4.1.0"
+      }
+    },
     "keycode": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/keycode/-/keycode-2.2.0.tgz",
@@ -13282,6 +13374,30 @@
         "object-keys": "^1.0.11"
       }
     },
+    "object.entries": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.1.tgz",
+      "integrity": "sha512-ilqR7BgdyZetJutmDPfXCDffGa0/Yzl2ivVNpbx/g4UeWrCdRnFDUBrKJGLhGieRHDATnyZXWBeCb29k9CJysQ==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.0-next.1",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3"
+      }
+    },
+    "object.fromentries": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.2.tgz",
+      "integrity": "sha512-r3ZiBH7MQppDJVLx6fhD618GKNG40CZYH9wgwdhKxBDDbQgjeWGGd4AtkZad84d291YxvWe7bJGuE65Anh0dxQ==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.0-next.1",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3"
+      }
+    },
     "object.getownpropertydescriptors": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.0.tgz",
@@ -13299,6 +13415,18 @@
       "dev": true,
       "requires": {
         "isobject": "^3.0.1"
+      }
+    },
+    "object.values": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.1.tgz",
+      "integrity": "sha512-WTa54g2K8iu0kmS/us18jEmdv1a4Wi//BZ/DTVYEcH0XhLM5NYdpDHja3gt57VrZLcNAO2WGA+KpWsDBaHt6eA==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.0-next.1",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3"
       }
     },
     "obuf": {
@@ -15942,6 +16070,16 @@
         "nanoid": "^2.1.0"
       }
     },
+    "side-channel": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.2.tgz",
+      "integrity": "sha512-7rL9YlPHg7Ancea1S96Pa8/QWb4BtXL/TZvS6B8XFetGBeuhAsfmUspK6DokBeZ64+Kj9TCNRD/30pVz1BvQNA==",
+      "dev": true,
+      "requires": {
+        "es-abstract": "^1.17.0-next.1",
+        "object-inspect": "^1.7.0"
+      }
+    },
     "signal-exit": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
@@ -16450,6 +16588,28 @@
       "requires": {
         "is-fullwidth-code-point": "^2.0.0",
         "strip-ansi": "^4.0.0"
+      }
+    },
+    "string.prototype.matchall": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.2.tgz",
+      "integrity": "sha512-N/jp6O5fMf9os0JU3E72Qhf590RSRZU/ungsL/qJUYVTNv7hTG0P/dbPjxINVN9jpscu3nzYwKESU3P3RY5tOg==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.0",
+        "has-symbols": "^1.0.1",
+        "internal-slot": "^1.0.2",
+        "regexp.prototype.flags": "^1.3.0",
+        "side-channel": "^1.0.2"
+      },
+      "dependencies": {
+        "has-symbols": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
+          "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
+          "dev": true
+        }
       }
     },
     "string.prototype.padend": {
@@ -19820,6 +19980,15 @@
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true
+    },
+    "xregexp": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/xregexp/-/xregexp-4.3.0.tgz",
+      "integrity": "sha512-7jXDIFXh5yJ/orPn4SXjuVrWWoi4Cr8jfV1eHv9CixKSbU+jY4mxfrBwAuDvupPNKpMUY+FeIqsVw/JLT9+B8g==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime-corejs3": "^7.8.3"
+      }
     },
     "xtend": {
       "version": "4.0.1",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@types/react-test-renderer": "^16.9.2",
     "@types/styled-components": "^5.0.1",
     "@types/webpack-env": "^1.15.1",
-    "@typescript-eslint/eslint-plugin": "^2.27.0",
+    "@typescript-eslint/eslint-plugin": "^2.28.0",
     "@typescript-eslint/parser": "^2.27.0",
     "css-loader": "^3.4.2",
     "eslint": "^6.8.0",

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "eslint-config-prettier": "^6.10.1",
     "eslint-plugin-prefer-arrow": "^1.2.0",
     "eslint-plugin-prettier": "^3.1.2",
+    "eslint-plugin-react": "^7.19.0",
     "file-loader": "^5.1.0",
     "fork-ts-checker-webpack-plugin": "^4.1.0",
     "husky": "^4.2.3",

--- a/shared/components/Table.tsx
+++ b/shared/components/Table.tsx
@@ -16,9 +16,7 @@ export const TableContext = React.createContext<TableContextProps>({
   sortTitle: "Sort",
   searchTexts: {},
   onSort: () => false,
-  onUpdateSearchText: (_: string) => (
-    __: React.ChangeEvent<HTMLInputElement>
-  ) => false
+  onUpdateSearchText: () => () => false
 })
 
 const Container = styled("table")`

--- a/shared/components/Table/SearchableHeader.tsx
+++ b/shared/components/Table/SearchableHeader.tsx
@@ -24,15 +24,11 @@ interface ArrowProps {
   active: boolean
 }
 
-const ArrowUp = styled(({ active, ...rest }) => <MdArrowDropUp {...rest} />)<
-  ArrowProps
->`
+const ArrowUp = styled(rest => <MdArrowDropUp {...rest} />)<ArrowProps>`
   color: ${props => (props.active ? "#229FC9" : "#84898C")};
 `
 
-const ArrowDown = styled(({ active, ...rest }) => (
-  <MdArrowDropDown {...rest} />
-))<ArrowProps>`
+const ArrowDown = styled(rest => <MdArrowDropDown {...rest} />)<ArrowProps>`
   color: ${props => (props.active ? "#229FC9" : "#84898C")};
   margin-top: -24px;
 `

--- a/shared/components/icons/Flag.tsx
+++ b/shared/components/icons/Flag.tsx
@@ -1,6 +1,6 @@
 import React from "react"
 
-export default ({ size = 16 }: { size?: number }) => (
+const Flag = ({ size = 16 }: { size?: number }) => (
   <svg width={size} height={size} viewBox="0 0 334 511" version="1.1">
     <g id="Page-1" stroke="none" strokeWidth="1" fill="none" fillRule="evenodd">
       <g id="Flag" transform="translate(14.000000, -16.000000)">
@@ -50,3 +50,5 @@ export default ({ size = 16 }: { size?: number }) => (
     </g>
   </svg>
 )
+
+export default Flag

--- a/shared/components/icons/PenPaper.tsx
+++ b/shared/components/icons/PenPaper.tsx
@@ -1,6 +1,6 @@
 import React from "react"
 
-export default ({
+const PenPaper = ({
   size = 16,
   color = "#fff"
 }: {
@@ -28,3 +28,5 @@ export default ({
     </g>
   </svg>
 )
+
+export default PenPaper

--- a/shared/components/icons/Ribbon.tsx
+++ b/shared/components/icons/Ribbon.tsx
@@ -1,6 +1,6 @@
 import React from "react"
 
-export default ({
+const Ribbon = ({
   size = 16,
   color = "#fff"
 }: {
@@ -36,3 +36,5 @@ export default ({
     </g>
   </svg>
 )
+
+export default Ribbon

--- a/shared/components/icons/User.tsx
+++ b/shared/components/icons/User.tsx
@@ -1,6 +1,6 @@
 import React from "react"
 
-export default ({
+const User = ({
   size = 16,
   color = "#fff"
 }: {
@@ -37,3 +37,5 @@ export default ({
     </g>
   </svg>
 )
+
+export default User

--- a/shared/components/react-jsonschema-form/TypeaheadField.tsx
+++ b/shared/components/react-jsonschema-form/TypeaheadField.tsx
@@ -243,7 +243,10 @@ class BaseTypeaheadField extends Component<
       this.props.onChange(schemaEvents)
       if (cleanAfterSelection) {
         setTimeout(() => {
+          // TODO Using this.refs is deprecated
+          // eslint-disable-next-line react/no-string-refs
           if (this.refs.typeahead) {
+            // eslint-disable-next-line react/no-string-refs
             this.refs.typeahead.getInstance().clear()
           }
         }, 0)
@@ -260,6 +263,7 @@ class BaseTypeaheadField extends Component<
       uiSchema: { focusOnMount = false }
     } = this.props
     if (focusOnMount) {
+      // eslint-disable-next-line react/no-string-refs
       this.refs.typeahead.getInstance().focus()
     }
   }
@@ -271,7 +275,9 @@ class BaseTypeaheadField extends Component<
       this.setState({
         selected: []
       })
+      // eslint-disable-next-line react/no-string-refs
       if (this.refs.typeahead && this.refs.typeahead.getInstance()) {
+        // eslint-disable-next-line react/no-string-refs
         this.refs.typeahead.getInstance().clear()
       }
       // let onChangeValue = getDefaultValueForSchema(schema);

--- a/shared/fetchUtils.ts
+++ b/shared/fetchUtils.ts
@@ -95,8 +95,7 @@ export function fetchUtils(
  * stores/mocks/[path_with_underscores][version number or 0].json
  */
 export const mockFetch = (apiUrl: (path: string) => string, version = 0) => (
-  url: string,
-  _init?: RequestInit
+  url: string
 ): Promise<Response> => {
   const path = url.replace(apiUrl(""), "")
   const mockResponse = {

--- a/shared/models/EnrichKoodiUri.ts
+++ b/shared/models/EnrichKoodiUri.ts
@@ -13,7 +13,7 @@ export const EnrichKoodiUri = types
   .model({})
   // we need this typing to avoid 'missing index signature' error
   // when assigning to self[dynamicKey]
-  .volatile((_): DynamicObject => ({}))
+  .volatile((): DynamicObject => ({}))
   .actions(self => {
     const { apiUrl, apiPrefix, errors, fetchSingle, callerId } = getEnv<
       StoreEnvironment

--- a/shared/models/EnrichOrganisaatioOid.ts
+++ b/shared/models/EnrichOrganisaatioOid.ts
@@ -14,7 +14,7 @@ export const EnrichOrganisaatioOid = (fieldPostfix: string) =>
     .model({})
     // we need this typing to avoid 'missing index signature' error
     // when assigning to self[dynamicKey]
-    .volatile((_): DynamicObject => ({}))
+    .volatile((): DynamicObject => ({}))
     .actions(self => {
       const { apiUrl, apiPrefix, errors, fetchSingle, callerId } = getEnv<
         StoreEnvironment

--- a/shared/models/EnrichTutkinnonOsa.ts
+++ b/shared/models/EnrichTutkinnonOsa.ts
@@ -13,7 +13,7 @@ export const EnrichTutkinnonOsa = (
   types
     .model({})
     .volatile(
-      (_): DynamicObject => ({
+      (): DynamicObject => ({
         disposeTutkinnonOsaFetcher: undefined as IReactionDisposer | undefined
       })
     )

--- a/shared/models/EnrichTutkinnonOsa.ts
+++ b/shared/models/EnrichTutkinnonOsa.ts
@@ -7,9 +7,7 @@ interface DynamicObject {
   [name: string]: any
 }
 
-export const EnrichTutkinnonOsa = (
-  fieldName: string = "tutkinnonOsaViitteet"
-) =>
+export const EnrichTutkinnonOsa = (fieldName = "tutkinnonOsaViitteet") =>
   types
     .model({})
     .volatile(

--- a/shared/models/HOKS.ts
+++ b/shared/models/HOKS.ts
@@ -60,7 +60,7 @@ const Model = types.model("HOKSModel", {
 
 export const HOKS = types
   .compose("HOKS", EnrichKoodiUri, Model)
-  .volatile(_ => ({
+  .volatile(() => ({
     osaamispisteet: 0
   }))
   .actions(self => {

--- a/shared/models/HOKS.ts
+++ b/shared/models/HOKS.ts
@@ -114,7 +114,7 @@ export const HOKS = types
 
     const fetchRakenne = flow(function*(
       id: string,
-      suoritustapa: string = "reformi"
+      suoritustapa = "reformi"
     ): any {
       const response: APIResponse = yield fetchSingle(
         apiUrl(

--- a/shared/responsive.tsx
+++ b/shared/responsive.tsx
@@ -11,9 +11,10 @@ interface MediaQueryProps extends ComponentWithTheme {
   breakpoint?: Breakpoints
   breakpointType?: "max" | "min"
   notMatch?: boolean
+  children: React.ReactNode
 }
 
-const MediaQuery: React.SFC<MediaQueryProps> = props => {
+const MediaQuery: React.SFC<MediaQueryProps> = (props: MediaQueryProps) => {
   const {
     theme,
     maxWidth,

--- a/shared/stores/NotificationStore.ts
+++ b/shared/stores/NotificationStore.ts
@@ -72,7 +72,7 @@ export const NotificationStore = types
     notifications: types.array(Notification),
     studentFeedbackLinks: types.array(types.string)
   })
-  .volatile(_ => ({
+  .volatile(() => ({
     showFeedbackModal: true
   }))
   .actions(self => {

--- a/shared/stores/ShareLinkStore.ts
+++ b/shared/stores/ShareLinkStore.ts
@@ -10,48 +10,46 @@ export const ShareLink = types.model("ShareLink", {
 
 export type IShareLink = Instance<typeof ShareLink>
 
-export const ShareLinkStore = types
-  .model("ShareLinkStore", {})
-  .actions(_self => {
-    // const { fetchCollection, errors, callerId } = getEnv<StoreEnvironment>(self)
+export const ShareLinkStore = types.model("ShareLinkStore", {}).actions(() => {
+  // const { fetchCollection, errors, callerId } = getEnv<StoreEnvironment>(self)
 
-    //const fetchLinks = flow(koodiUri: string, type: string) {
-    const fetchLinks = function(koodiUri: string, type: string) {
-      console.log("fetching share links for", koodiUri, type)
+  //const fetchLinks = flow(koodiUri: string, type: string) {
+  const fetchLinks = function(koodiUri: string, type: string) {
+    console.log("fetching share links for", koodiUri, type)
 
-      // TODO: mock data, replace with real API call
-      return Promise.resolve([
-        {
-          id: 1,
-          createdAt: "2019-05-01",
-          validFrom: "2019-06-01",
-          validTo: "2019-06-30",
-          url: "https://ehoks.dev/share/1"
-        },
-        {
-          id: 2,
-          createdAt: "2019-05-02",
-          validFrom: "2019-07-01",
-          validTo: "2019-07-08",
-          url: "https://ehoks.dev/share/2"
-        },
-        {
-          id: 3,
-          createdAt: "2019-05-03",
-          validFrom: "2019-09-01",
-          validTo: "2019-09-30",
-          url: "https://ehoks.dev/share/3"
-        }
-      ]) as Promise<Instance<typeof ShareLink>[]>
-      // try {
-      //   const response = yield fetchCollection(apiUrl("shareLinks"),{ headers: callerId() })
-      //   return response.data
-      // } catch (error) {
-      //   errors.logError("ShareLinkStore.fetchLinks", error.message)
-      // }
-    }
+    // TODO: mock data, replace with real API call
+    return Promise.resolve([
+      {
+        id: 1,
+        createdAt: "2019-05-01",
+        validFrom: "2019-06-01",
+        validTo: "2019-06-30",
+        url: "https://ehoks.dev/share/1"
+      },
+      {
+        id: 2,
+        createdAt: "2019-05-02",
+        validFrom: "2019-07-01",
+        validTo: "2019-07-08",
+        url: "https://ehoks.dev/share/2"
+      },
+      {
+        id: 3,
+        createdAt: "2019-05-03",
+        validFrom: "2019-09-01",
+        validTo: "2019-09-30",
+        url: "https://ehoks.dev/share/3"
+      }
+    ]) as Promise<Instance<typeof ShareLink>[]>
+    // try {
+    //   const response = yield fetchCollection(apiUrl("shareLinks"),{ headers: callerId() })
+    //   return response.data
+    // } catch (error) {
+    //   errors.logError("ShareLinkStore.fetchLinks", error.message)
+    // }
+  }
 
-    return { fetchLinks }
-  })
+  return { fetchLinks }
+})
 
 export type IShareLinkStore = Instance<typeof ShareLinkStore>

--- a/shared/styleguide/StyleguidistWrapper.tsx
+++ b/shared/styleguide/StyleguidistWrapper.tsx
@@ -3,7 +3,9 @@ import { IntlProvider } from "react-intl"
 import { ThemeWrapper } from "components/ThemeWrapper"
 import { Locale } from "../stores/TranslationStore"
 
-export default class StyleguidistWrapper extends React.Component {
+export default class StyleguidistWrapper extends React.Component<{
+  children: React.ReactNode
+}> {
   render() {
     return (
       <ThemeWrapper>

--- a/virkailija/src/routes/HOKSLomake/ArrayFieldTemplate.tsx
+++ b/virkailija/src/routes/HOKSLomake/ArrayFieldTemplate.tsx
@@ -118,7 +118,7 @@ export function ArrayFieldTemplate(props: ArrayFieldTemplateProps) {
   const onAdd = useCallback(
     (event: React.MouseEvent<HTMLButtonElement>) => {
       onAddClick(event)
-      setActiveStep(_ => items.length)
+      setActiveStep(() => items.length)
     },
     [onAddClick, setActiveStep, items]
   )

--- a/virkailija/src/routes/HOKSLomake/CustomBaseInput.tsx
+++ b/virkailija/src/routes/HOKSLomake/CustomBaseInput.tsx
@@ -32,11 +32,7 @@ function CustomBaseInput(props: CustomBaseInputProps) {
     autofocus,
     onBlur,
     onFocus,
-    options,
     schema,
-    formContext,
-    registry,
-    rawErrors,
     ...inputProps
   } = props
 

--- a/virkailija/src/routes/HOKSLomake/CustomBooleanRadioButtonWidget.tsx
+++ b/virkailija/src/routes/HOKSLomake/CustomBooleanRadioButtonWidget.tsx
@@ -23,7 +23,7 @@ export function CustomBooleanRadioButtonWidget(props: WidgetProps) {
               required={required}
               value={option.value}
               autoFocus={autofocus && i === 0}
-              onChange={_ => onChange(option.value)}
+              onChange={() => onChange(option.value)}
             />
             <span>{option.label}</span>
           </span>

--- a/virkailija/src/routes/HOKSLomake/helpers/idToPathArray.ts
+++ b/virkailija/src/routes/HOKSLomake/helpers/idToPathArray.ts
@@ -1,2 +1,1 @@
-export const idToPathArray = (id: string = "") =>
-  id.replace("root_", "").split("_")
+export const idToPathArray = (id = "") => id.replace("root_", "").split("_")

--- a/virkailija/src/routes/HOKSLomake/helpers/idToTranslationKey.ts
+++ b/virkailija/src/routes/HOKSLomake/helpers/idToTranslationKey.ts
@@ -1,7 +1,7 @@
 import camelCase from "lodash.camelcase"
 import { idToPathArray } from "./idToPathArray"
 
-export function idToTranslationKey(id: string = "") {
+export function idToTranslationKey(id = "") {
   const key = idToPathArray(id)
     .map(part => {
       if (!isNaN(Number(part))) {

--- a/virkailija/src/routes/HOKSLomake/helpers/schemaToTranslations.ts
+++ b/virkailija/src/routes/HOKSLomake/helpers/schemaToTranslations.ts
@@ -7,7 +7,7 @@ import { idToTranslationKey } from "./idToTranslationKey"
 // formatted for localisation service
 export function schemaToTranslations(
   schema: any,
-  prevPath: string = "",
+  prevPath = "",
   definitions?: any
 ) {
   const defs = definitions || schema.definitions

--- a/virkailija/src/stores/KoulutuksenJarjestajaStore.ts
+++ b/virkailija/src/stores/KoulutuksenJarjestajaStore.ts
@@ -146,7 +146,7 @@ const Search = types
     sortDirection: "asc",
     perPage: 10
   })
-  .volatile((_): { searchTexts: { [key in SearchSortKey]: string } } => ({
+  .volatile((): { searchTexts: { [key in SearchSortKey]: string } } => ({
     searchTexts: {
       nimi: "",
       tutkinto: "",

--- a/virkailija/src/stores/KoulutuksenJarjestajaStore.ts
+++ b/virkailija/src/stores/KoulutuksenJarjestajaStore.ts
@@ -219,10 +219,7 @@ const Search = types
     return { fetchOppijat, resetActivePage }
   })
   .actions(self => {
-    const changeSearchText = (
-      field: SearchSortKey,
-      searchText: string = ""
-    ) => {
+    const changeSearchText = (field: SearchSortKey, searchText = "") => {
       self.activePage = 0
       // create new object ref as volatile data is not mobx observable
       self.searchTexts = { ...self.searchTexts, [field]: searchText }


### PR DESCRIPTION
- eslint-plugin-react
- @typescript-eslint/eslint-plugin

*react/no-string-refs* using string identifier is deprecaded and used in https://github.com/Opetushallitus/ehoks-ui/compare/eh-896-redefine-eslint-rules?expand=1#diff-3dc81b1e748108800d76cc83a46f7c64R247
More info:
https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-string-refs.md
https://github.com/ericgio/react-bootstrap-typeahead/blob/master/docs/Methods.md