### PR TITLE
jest config change

### DIFF
--- a/oppija/jest.config.js
+++ b/oppija/jest.config.js
@@ -3,6 +3,7 @@ module.exports = {
   setupFilesAfterEnv: ["<rootDir>/../shared/setupTests.ts"],
   modulePaths: ["<rootDir>/src", "<rootDir>/../shared"],
   roots: ["<rootDir>", "<rootDir>/../shared"],
+  testMatch: ["**/__tests__/**/*.ts?(x)", "**/?(*.)+(spec|test).ts?(x)"],
   moduleNameMapper: {
     "\\.(css|jpg|png|svg)$": "<rootDir>/empty-module.js"
   }

--- a/tyopaikantoimija/jest.config.js
+++ b/tyopaikantoimija/jest.config.js
@@ -3,6 +3,7 @@ module.exports = {
   setupFilesAfterEnv: ["<rootDir>/../shared/setupTests.ts"],
   modulePaths: ["<rootDir>/src", "<rootDir>/../shared"],
   roots: ["<rootDir>", "<rootDir>/../shared"],
+  testMatch: ["**/__tests__/**/*.ts?(x)", "**/?(*.)+(spec|test).ts?(x)"],
   moduleNameMapper: {
     "\\.(css|jpg|png|svg)$": "<rootDir>/empty-module.js"
   }

--- a/virkailija/jest.config.js
+++ b/virkailija/jest.config.js
@@ -3,6 +3,7 @@ module.exports = {
   setupFilesAfterEnv: ["<rootDir>/../shared/setupTests.ts"],
   modulePaths: ["<rootDir>/src", "<rootDir>/../shared"],
   roots: ["<rootDir>", "<rootDir>/../shared"],
+  testMatch: ["**/__tests__/**/*.ts?(x)", "**/?(*.)+(spec|test).ts?(x)"],
   moduleNameMapper: {
     "\\.(css|jpg|png|svg)$": "<rootDir>/empty-module.js"
   }


### PR DESCRIPTION
Made Jest search tests only from typescript files. 
Default for testMatch is [ "**/__tests__/**/*.[jt]s?(x)", "**/?(*.)+(spec|test).[jt]s?(x)" ] 
![jest](https://user-images.githubusercontent.com/50478518/86220149-d369dc80-bb8b-11ea-8630-c8fba2471dbe.png)
https://jestjs.io/docs/en/configuration#testmatch-arraystring


meaning js files would be searched also but we don't have need for that.