### PR TITLE
Fix React-Axe source-map log error

### DIFF
--- a/oppija/webpack.config.js
+++ b/oppija/webpack.config.js
@@ -73,7 +73,7 @@ module.exports = {
         enforce: "pre",
         use: "source-map-loader",
         // these packages have problems with their sourcemaps
-        exclude: [/node_modules\/react-responsive/]
+        exclude: [/node_modules\/react-responsive/, /node_modules\/react-axe/]
       },
       // Load images with 'file-loader'.
       {

--- a/oppija/webpack.config.js
+++ b/oppija/webpack.config.js
@@ -1,9 +1,10 @@
-var webpack = require("webpack")
-var path = require("path")
-var ForkTsCheckerWebpackPlugin = require("fork-ts-checker-webpack-plugin")
-var TsconfigPathsPlugin = require("tsconfig-paths-webpack-plugin")
-var createStyledComponentsTransformer = require('typescript-plugin-styled-components').default
-var styledComponentsTransformer = createStyledComponentsTransformer()
+const webpack = require("webpack")
+const path = require("path")
+const ForkTsCheckerWebpackPlugin = require("fork-ts-checker-webpack-plugin")
+const TsconfigPathsPlugin = require("tsconfig-paths-webpack-plugin")
+const createStyledComponentsTransformer = require("typescript-plugin-styled-components")
+  .default
+const styledComponentsTransformer = createStyledComponentsTransformer()
 
 module.exports = {
   mode: "development",
@@ -59,7 +60,9 @@ module.exports = {
             options: {
               transpileOnly: true,
               experimentalWatchApi: true,
-              getCustomTransformers: () => ({ before: [styledComponentsTransformer] })
+              getCustomTransformers: () => ({
+                before: [styledComponentsTransformer]
+              })
             }
           }
         ]
@@ -70,8 +73,7 @@ module.exports = {
         enforce: "pre",
         use: "source-map-loader",
         // these packages have problems with their sourcemaps
-        exclude: [
-          /node_modules\/react-responsive/]
+        exclude: [/node_modules\/react-responsive/]
       },
       // Load images with 'file-loader'.
       {

--- a/shared/styleguide/webpack.config.js
+++ b/shared/styleguide/webpack.config.js
@@ -1,5 +1,5 @@
-var webpack = require("webpack")
-var path = require("path")
+const webpack = require("webpack")
+const path = require("path")
 
 module.exports = {
   mode: "development",

--- a/tyopaikantoimija/webpack.config.js
+++ b/tyopaikantoimija/webpack.config.js
@@ -1,10 +1,10 @@
-var webpack = require("webpack")
-var path = require("path")
-var ForkTsCheckerWebpackPlugin = require("fork-ts-checker-webpack-plugin")
-var TsconfigPathsPlugin = require("tsconfig-paths-webpack-plugin")
-var createStyledComponentsTransformer = require("typescript-plugin-styled-components")
+const webpack = require("webpack")
+const path = require("path")
+const ForkTsCheckerWebpackPlugin = require("fork-ts-checker-webpack-plugin")
+const TsconfigPathsPlugin = require("tsconfig-paths-webpack-plugin")
+const createStyledComponentsTransformer = require("typescript-plugin-styled-components")
   .default
-var styledComponentsTransformer = createStyledComponentsTransformer()
+const styledComponentsTransformer = createStyledComponentsTransformer()
 
 module.exports = {
   mode: "development",

--- a/tyopaikantoimija/webpack.config.js
+++ b/tyopaikantoimija/webpack.config.js
@@ -73,7 +73,7 @@ module.exports = {
         enforce: "pre",
         use: "source-map-loader",
         // these packages have problems with their sourcemaps
-        exclude: [/node_modules\/react-responsive/]
+        exclude: [/node_modules\/react-responsive/, /node_modules\/react-axe/]
       },
       // Load images with 'file-loader'.
       {

--- a/virkailija/webpack.config.js
+++ b/virkailija/webpack.config.js
@@ -1,9 +1,10 @@
-var webpack = require("webpack")
-var path = require("path")
-var ForkTsCheckerWebpackPlugin = require("fork-ts-checker-webpack-plugin")
-var TsconfigPathsPlugin = require("tsconfig-paths-webpack-plugin")
-var createStyledComponentsTransformer = require('typescript-plugin-styled-components').default
-var styledComponentsTransformer = createStyledComponentsTransformer()
+const webpack = require("webpack")
+const path = require("path")
+const ForkTsCheckerWebpackPlugin = require("fork-ts-checker-webpack-plugin")
+const TsconfigPathsPlugin = require("tsconfig-paths-webpack-plugin")
+const createStyledComponentsTransformer = require("typescript-plugin-styled-components")
+  .default
+const styledComponentsTransformer = createStyledComponentsTransformer()
 
 module.exports = {
   mode: "development",
@@ -59,7 +60,9 @@ module.exports = {
             options: {
               transpileOnly: true,
               experimentalWatchApi: true,
-              getCustomTransformers: () => ({ before: [styledComponentsTransformer] })
+              getCustomTransformers: () => ({
+                before: [styledComponentsTransformer]
+              })
             }
           }
         ]
@@ -71,7 +74,8 @@ module.exports = {
         // these packages have problems with their sourcemaps
         exclude: [
           /node_modules\/@opetushallitus\/virkailija-ui-components/,
-          /node_modules\/react-responsive/]
+          /node_modules\/react-responsive/
+        ]
       },
       {
         test: /\.css$/,

--- a/virkailija/webpack.config.js
+++ b/virkailija/webpack.config.js
@@ -74,7 +74,8 @@ module.exports = {
         // these packages have problems with their sourcemaps
         exclude: [
           /node_modules\/@opetushallitus\/virkailija-ui-components/,
-          /node_modules\/react-responsive/
+          /node_modules\/react-responsive/,
+          /node_modules\/react-axe/
         ]
       },
       {


### PR DESCRIPTION
Run `npm i` to get React-axe installed to your dev environment if you haven't previsouly.