### PR TITLE
EH-747: Tutkinnon osa id from eperusteet

### DIFF
--- a/shared/models/Enrichment/EnrichTutkinnonOsaAndOsaAlueet.ts
+++ b/shared/models/Enrichment/EnrichTutkinnonOsaAndOsaAlueet.ts
@@ -40,7 +40,7 @@ export const EnrichTutkinnonOsaAndOsaAlueet = types
         const response: APIResponse = yield cachedTutkinnonOsaResponses[
           koodiUri
         ]
-        self.tutkinnonOsa = response.data
+        self.tutkinnonOsaId = response.data.id
       } catch (error) {
         errors.logError("EnrichKoodiUri.fetchEPerusteet", error.message)
       }
@@ -95,7 +95,7 @@ export const EnrichTutkinnonOsaAndOsaAlueet = types
       tutkinnonOsaKoodiUri: string
     ): any {
       yield fetchTutkinnonOsa(tutkinnonOsaKoodiUri)
-      yield fetchOsaAlue(self.tutkinnonOsa.id)
+      yield fetchOsaAlue(self.tutkinnonOsaId)
     })
 
     const afterCreate = () => {

--- a/shared/models/YhteinenTutkinnonOsa/AiemminHankittuYhteinenTutkinnonOsa.ts
+++ b/shared/models/YhteinenTutkinnonOsa/AiemminHankittuYhteinenTutkinnonOsa.ts
@@ -2,7 +2,6 @@ import { types } from "mobx-state-tree"
 import { OsaamisenOsoittaminen } from "../OsaamisenOsoittaminen"
 import { TodennettuArviointiLisatiedot } from "../TodennettuArviointiLisatiedot"
 import { AiemminHankitunYTOOsaAlue } from "./AiemminHankitunYTOOsaAlue"
-import { EPerusteetVastaus } from "models/EPerusteetVastaus"
 import { TutkinnonOsaViite } from "models/TutkinnonOsaViite"
 import { TutkinnonOsaType } from "../helpers/ShareTypes"
 import { EnrichTutkinnonOsaAndOsaAlueet } from "../Enrichment/EnrichTutkinnonOsaAndOsaAlueet"
@@ -11,7 +10,7 @@ const Model = types.model({
   id: types.optional(types.number, 0),
   moduleId: types.maybe(types.string),
   tutkinnonOsaKoodiUri: types.optional(types.string, ""),
-  tutkinnonOsa: types.optional(EPerusteetVastaus, {}),
+  tutkinnonOsaId: types.maybe(types.number),
   tutkinnonOsaViitteet: types.array(TutkinnonOsaViite),
   koulutuksenJarjestajaOid: types.optional(types.string, ""),
   osaAlueet: types.array(AiemminHankitunYTOOsaAlue),

--- a/shared/models/YhteinenTutkinnonOsa/HankittavaYhteinenTutkinnonOsa.ts
+++ b/shared/models/YhteinenTutkinnonOsa/HankittavaYhteinenTutkinnonOsa.ts
@@ -1,13 +1,12 @@
 import { types } from "mobx-state-tree"
 import { YhteisenTutkinnonOsanOsaAlue } from "./YhteisenTutkinnonOsanOsaAlue"
-import { EPerusteetVastaus } from "models/EPerusteetVastaus"
 import { TutkinnonOsaType } from "../helpers/ShareTypes"
 import { EnrichTutkinnonOsaAndOsaAlueet } from "../Enrichment/EnrichTutkinnonOsaAndOsaAlueet"
 
 export const Model = types.model({
   moduleId: types.maybe(types.string),
   tutkinnonOsaKoodiUri: types.optional(types.string, ""),
-  tutkinnonOsa: types.optional(EPerusteetVastaus, {}),
+  tutkinnonOsaId: types.maybe(types.number),
   koulutuksenJarjestajaOid: types.optional(types.string, ""),
   osaAlueet: types.array(YhteisenTutkinnonOsanOsaAlue)
 })


### PR DESCRIPTION
Yhteisten tutkinnon osien mst-modeleihin sijoitettiin iso läjä eperusteista tulevaa dataa mutta oikeasti ainoa tarvittava tieto on tutkinnon osan id, jonka avulla osa-alueet rikastetaan. Poistettu ytoilta TutkinnonOsa property ja lisätty tutkinnonOsaId.