### PR TITLE
Eh 1035 banner aria role removed

### DIFF
--- a/oppija/src/routes/Etusivu.tsx
+++ b/oppija/src/routes/Etusivu.tsx
@@ -163,7 +163,7 @@ export class Etusivu extends React.Component<EtusivuProps> {
         </Header>
 
         <ContentContainer>
-          <LoginBoxes role="banner">
+          <LoginBoxes>
             <LoginContainer>
               <LoginTitle>
                 <h2>

--- a/oppija/src/routes/__tests__/__snapshots__/App.test.tsx.snap
+++ b/oppija/src/routes/__tests__/__snapshots__/App.test.tsx.snap
@@ -804,7 +804,6 @@ exports[`App renders correctly 1`] = `
             >
               <div
                 class="c17"
-                role="banner"
               >
                 <div
                   class="c18"


### PR DESCRIPTION
Poistettu oppijan etusivun kirjautumislaatikolta banner aria role koska oli hämäävä. Banneria kuuluisi käyttää elementissä joka sisältää sivustokohtaista tietoa, ei sivukohtaista. Banneriin kuuluvaa tietoa on esim logo, firman nimi, slogan, hakuikoni.