### PR TITLE
Eh 1063 add hoks eid to linkinjako

### DIFF
--- a/oppija/src/index.tsx
+++ b/oppija/src/index.tsx
@@ -27,7 +27,7 @@ store.translations.fetchLocales()
 const apiConfig = { apiUrl, apiPrefix }
 const appContext = {
   app: "oppija",
-  featureFlags: { shareDialog: false, shareNotifications: false }
+  featureFlags: { shareDialog: true, shareNotifications: true }
 }
 
 // initial render to app container

--- a/shared/components/Opiskelija/StudyPlan/CompletedStudies.tsx
+++ b/shared/components/Opiskelija/StudyPlan/CompletedStudies.tsx
@@ -16,6 +16,7 @@ export interface CompletedStudiesProps {
     moduleId?: string
     tutkinnonOsaTyyppi?: TutkinnonOsaType
     tutkinnonOsaModuleId?: string
+    hoksEid?: string
   }
   hasActiveShare: boolean
   toggleAccordion: (

--- a/shared/components/Opiskelija/StudyPlan/CompletedStudies.tsx
+++ b/shared/components/Opiskelija/StudyPlan/CompletedStudies.tsx
@@ -18,6 +18,7 @@ export interface CompletedStudiesProps {
     tutkinnonOsaModuleId?: string
     hoksEid?: string
   }
+  hoksEid?: string
   hasActiveShare: boolean
   toggleAccordion: (
     accordion: ActiveAccordions,
@@ -41,7 +42,8 @@ export class CompletedStudies extends React.Component<CompletedStudiesProps> {
       toggleAccordion,
       valmiitOpinnot,
       elements = {},
-      competencePointsTitle
+      competencePointsTitle,
+      hoksEid
     } = this.props
 
     return (
@@ -78,6 +80,7 @@ export class CompletedStudies extends React.Component<CompletedStudiesProps> {
                   fadedColor="#ECF6ED"
                   koodiUri={study.tutkinnonOsaKoodiUri}
                   moduleId={study.moduleId}
+                  hoksEid={hoksEid}
                   tutkinnonOsaTyyppi={study.tutkinnonOsaTyyppi}
                   tutkinnonOsaModuleId={study.tutkinnonOsaModuleId}
                   osaamisenHankkimistavat={study.osaamisenHankkimistavat}

--- a/shared/components/Opiskelija/StudyPlan/Opiskelusuunnitelma.tsx
+++ b/shared/components/Opiskelija/StudyPlan/Opiskelusuunnitelma.tsx
@@ -110,7 +110,8 @@ export class Opiskelusuunnitelma extends React.Component<
       type: undefined,
       moduleId: undefined,
       tutkinnonOsaTyyppi: undefined,
-      tutkinnonOsaModuleId: undefined
+      tutkinnonOsaModuleId: undefined,
+      hoksEid: this.props.plan.eid
     }
   }
 
@@ -124,7 +125,8 @@ export class Opiskelusuunnitelma extends React.Component<
           type: share.type,
           moduleId: share.moduleId,
           tutkinnonOsaTyyppi: share.tutkinnonOsaTyyppi,
-          tutkinnonOsaModuleId: share.tutkinnonOsaModuleId
+          tutkinnonOsaModuleId: share.tutkinnonOsaModuleId,
+          hoksEid: share.hoksEid
         }
       }))
       this.setInitialExpanded(share)

--- a/shared/components/Opiskelija/StudyPlan/Opiskelusuunnitelma.tsx
+++ b/shared/components/Opiskelija/StudyPlan/Opiskelusuunnitelma.tsx
@@ -111,8 +111,9 @@ export class Opiskelusuunnitelma extends React.Component<
       moduleId: undefined,
       tutkinnonOsaTyyppi: undefined,
       tutkinnonOsaModuleId: undefined,
-      hoksEid: this.props.plan.eid
-    }
+      hoksEid: undefined
+    },
+    hoksEid: this.props.plan.eid
   }
 
   async componentDidMount() {
@@ -145,7 +146,8 @@ export class Opiskelusuunnitelma extends React.Component<
             type: share.type,
             moduleId: share.moduleId,
             tutkinnonOsaTyyppi: share.tutkinnonOsaTyyppi,
-            tutkinnonOsaModuleId: share.tutkinnonOsaModuleId
+            tutkinnonOsaModuleId: share.tutkinnonOsaModuleId,
+            hoksEid: share.hoksEid
           }
         }))
       }
@@ -157,6 +159,7 @@ export class Opiskelusuunnitelma extends React.Component<
     moduleId: string | ""
     tutkinnonOsaTyyppi?: TutkinnonOsaType
     tutkinnonOsaModuleId: string | ""
+    hoksEid: string | ""
   }) {
     return (
       share.type !== this.state.share.type ||
@@ -261,7 +264,7 @@ export class Opiskelusuunnitelma extends React.Component<
 
   render() {
     const { intl } = this.context
-    const { activeAccordions, share } = this.state
+    const { activeAccordions, share, hoksEid } = this.state
     const { plan, elements: customElements = {} } = this.props
     const { suunnitellutOpinnot, aikataulutetutOpinnot, valmiitOpinnot } = plan
     const competencePointsTitle = intl.formatMessage({
@@ -364,6 +367,7 @@ export class Opiskelusuunnitelma extends React.Component<
             competencePointsTitle={competencePointsTitle}
             hasActiveShare={hasActiveShare("suunnitellut")}
             share={share}
+            hoksEid={hoksEid}
             suunnitellutOpinnot={suunnitellutOpinnot}
             elements={elements}
             toggleAccordion={this.toggleAccordion}
@@ -371,6 +375,7 @@ export class Opiskelusuunnitelma extends React.Component<
           <ScheduledStudies
             accordionIsOpen={activeAccordions.suunnitelmat.aikataulutetut}
             share={share}
+            hoksEid={hoksEid}
             hasActiveShare={hasActiveShare("aikataulutetut")}
             toggleAccordion={this.toggleAccordion}
             aikataulutetutOpinnot={aikataulutetutOpinnot}
@@ -380,6 +385,7 @@ export class Opiskelusuunnitelma extends React.Component<
           <CompletedStudies
             accordionIsOpen={activeAccordions.suunnitelmat.valmiit}
             share={share}
+            hoksEid={hoksEid}
             hasActiveShare={hasActiveShare("valmiit")}
             toggleAccordion={this.toggleAccordion}
             valmiitOpinnot={valmiitOpinnot}

--- a/shared/components/Opiskelija/StudyPlan/PlannedStudies.tsx
+++ b/shared/components/Opiskelija/StudyPlan/PlannedStudies.tsx
@@ -18,6 +18,7 @@ export interface PlannedStudiesProps {
     tutkinnonOsaModuleId?: string
     hoksEid?: string
   }
+  hoksEid?: string
   hasActiveShare: boolean
   toggleAccordion: (
     accordion: ActiveAccordions,
@@ -37,6 +38,7 @@ export class PlannedStudies extends React.Component<PlannedStudiesProps> {
     const {
       accordionIsOpen,
       share,
+      hoksEid,
       hasActiveShare,
       toggleAccordion,
       suunnitellutOpinnot,
@@ -78,6 +80,7 @@ export class PlannedStudies extends React.Component<PlannedStudiesProps> {
                   fadedColor="#FDF1E6"
                   koodiUri={study.tutkinnonOsaKoodiUri}
                   moduleId={study.moduleId}
+                  hoksEid={hoksEid}
                   tutkinnonOsaTyyppi={study.tutkinnonOsaTyyppi}
                   tutkinnonOsaModuleId={study.tutkinnonOsaModuleId}
                   osaamisenHankkimistavat={study.osaamisenHankkimistavat}

--- a/shared/components/Opiskelija/StudyPlan/PlannedStudies.tsx
+++ b/shared/components/Opiskelija/StudyPlan/PlannedStudies.tsx
@@ -16,6 +16,7 @@ export interface PlannedStudiesProps {
     moduleId?: string
     tutkinnonOsaTyyppi?: TutkinnonOsaType
     tutkinnonOsaModuleId?: string
+    hoksEid?: string
   }
   hasActiveShare: boolean
   toggleAccordion: (

--- a/shared/components/Opiskelija/StudyPlan/ScheduledStudies.tsx
+++ b/shared/components/Opiskelija/StudyPlan/ScheduledStudies.tsx
@@ -18,6 +18,7 @@ export interface ScheduledStudiesProps {
     tutkinnonOsaModuleId?: string
     hoksEid?: string
   }
+  hoksEid?: string
   hasActiveShare: boolean
   toggleAccordion: (
     accordion: ActiveAccordions,
@@ -37,6 +38,7 @@ export class ScheduledStudies extends React.Component<ScheduledStudiesProps> {
     const {
       accordionIsOpen,
       share,
+      hoksEid,
       hasActiveShare,
       toggleAccordion,
       aikataulutetutOpinnot,
@@ -81,6 +83,7 @@ export class ScheduledStudies extends React.Component<ScheduledStudiesProps> {
                   tutkinnonOsaTyyppi={study.tutkinnonOsaTyyppi}
                   osaamisenHankkimistavat={study.osaamisenHankkimistavat}
                   share={share}
+                  hoksEid={hoksEid}
                   title={study.opintoOtsikko(competencePointsTitle)}
                   objectives={study.tavoitteetJaSisallot}
                   koulutuksenJarjestaja={study.koulutuksenJarjestaja}

--- a/shared/components/Opiskelija/StudyPlan/ScheduledStudies.tsx
+++ b/shared/components/Opiskelija/StudyPlan/ScheduledStudies.tsx
@@ -16,6 +16,7 @@ export interface ScheduledStudiesProps {
     moduleId?: string
     tutkinnonOsaTyyppi?: TutkinnonOsaType
     tutkinnonOsaModuleId?: string
+    hoksEid?: string
   }
   hasActiveShare: boolean
   toggleAccordion: (

--- a/shared/components/Opiskelija/StudyPlan/StudyPlanHelpers.ts
+++ b/shared/components/Opiskelija/StudyPlan/StudyPlanHelpers.ts
@@ -18,6 +18,7 @@ export interface OpiskelusuunnitelmaState {
     tutkinnonOsaModuleId?: string
     hoksEid?: string
   }
+  hoksEid?: string
 }
 
 export type StudyPartType = "aikataulutetut" | "suunnitellut" | "valmiit"

--- a/shared/components/Opiskelija/StudyPlan/StudyPlanHelpers.ts
+++ b/shared/components/Opiskelija/StudyPlan/StudyPlanHelpers.ts
@@ -16,6 +16,7 @@ export interface OpiskelusuunnitelmaState {
     moduleId?: string
     tutkinnonOsaTyyppi?: TutkinnonOsaType
     tutkinnonOsaModuleId?: string
+    hoksEid?: string
   }
 }
 

--- a/shared/components/ShareDialog.tsx
+++ b/shared/components/ShareDialog.tsx
@@ -149,6 +149,7 @@ interface ShareDialogProps extends InjectedIntlProps {
   /* Used version of react-intl cannot handle React.ReactNode here */
   children: any
   moduleId: string
+  hoksEid: string
   type: ShareType
   defaultPeriod?: ShareLinkValidityPeriod
   instructor?: Instructor
@@ -165,6 +166,7 @@ export function ShareDialog(props: ShareDialogProps) {
     defaultPeriod,
     instructor,
     moduleId,
+    hoksEid,
     type,
     tutkinnonOsaTyyppi,
     tutkinnonOsaModuleId,
@@ -204,6 +206,7 @@ export function ShareDialog(props: ShareDialogProps) {
     if (tutkinnonOsaTyyppi) {
       const createdUuid = await createLink({
         moduleId,
+        hoksEid,
         startDate,
         endDate,
         type,

--- a/shared/components/ShareDialog.tsx
+++ b/shared/components/ShareDialog.tsx
@@ -109,6 +109,10 @@ const LinkAnchor = styled(LinkItem)`
   flex: unset;
 `
 
+const RemoveLinkButton = styled(LinkButton)`
+  color: #1976d2;
+`
+
 const ChildContainer = styled("div")`
   border: 1px solid #979797;
   background: ${(props: ColorProps) => props.background};
@@ -334,7 +338,7 @@ export function ShareDialog(props: ShareDialogProps) {
                 </LinkItem>
                 <LinkItem>{link.jakoUuid}</LinkItem>
                 <LinkAnchor>
-                  <LinkButton
+                  <RemoveLinkButton
                     onClick={(event: React.MouseEvent) =>
                       remove(event, link.jakoUuid)
                     }
@@ -343,7 +347,7 @@ export function ShareDialog(props: ShareDialogProps) {
                       id="jakaminen.poistaLinkki"
                       defaultMessage="Poista linkki"
                     />
-                  </LinkButton>
+                  </RemoveLinkButton>
                 </LinkAnchor>
               </SharedLink>
             ))}

--- a/shared/components/ShareDialog/API.ts
+++ b/shared/components/ShareDialog/API.ts
@@ -44,6 +44,7 @@ export const createLink = async function({
   startDate,
   endDate,
   moduleId,
+  hoksEid,
   type,
   tutkinnonOsaTyyppi,
   tutkinnonOsaModuleId,
@@ -52,6 +53,7 @@ export const createLink = async function({
   startDate: string
   endDate: string
   moduleId: string
+  hoksEid: string
   type: string
   tutkinnonOsaTyyppi: TutkinnonOsaType
   tutkinnonOsaModuleId: string
@@ -70,7 +72,8 @@ export const createLink = async function({
       "shared-module-uuid": moduleId,
       "shared-module-tyyppi": type,
       "voimassaolo-alku": startDate,
-      "voimassaolo-loppu": endDate
+      "voimassaolo-loppu": endDate,
+      "hoks-eid": hoksEid
     })
   })
 

--- a/shared/components/ShareDialog/API.ts
+++ b/shared/components/ShareDialog/API.ts
@@ -2,7 +2,7 @@ import { APIConfig } from "components/APIConfigContext"
 import { TutkinnonOsaType } from "../../models/helpers/ShareTypes"
 
 interface BackendShareLink {
-  "jako-uuid": string
+  "share-id": string
   "module-id": string
   "voimassaolo-alku": string
   "voimassaolo-loppu": string
@@ -32,11 +32,10 @@ export const fetchLinks = async function(
   }
   const json: { data: BackendShareLink[] } = await response.json()
   return json.data.map(link => ({
-    jakoUuid: link["jako-uuid"],
+    jakoUuid: link["share-id"],
     validFrom: link["voimassaolo-alku"],
     validTo: link["voimassaolo-loppu"],
-    type: link.tyyppi,
-    moduleId: link["module-id"]
+    type: link.tyyppi
   }))
 }
 

--- a/shared/components/TutkinnonOsa.tsx
+++ b/shared/components/TutkinnonOsa.tsx
@@ -96,6 +96,7 @@ export interface TutkinnonOsaProps {
    */
   koodiUri?: string
   moduleId?: string
+  hoksEid?: string
   /**
    * List of learning periods.
    * @default []
@@ -109,6 +110,7 @@ export interface TutkinnonOsaProps {
     moduleId?: string
     tutkinnonOsaTyyppi?: TutkinnonOsaType
     tutkinnonOsaModuleId?: string
+    hoksEid?: string
   }
   /** Title of the study, always visible */
   title?: React.ReactNode
@@ -216,14 +218,15 @@ export class TutkinnonOsa extends React.Component<
   }
 
   share = () => {
-    const { moduleId, tutkinnonOsaTyyppi } = this.props
-    if (moduleId && tutkinnonOsaTyyppi) {
+    const { moduleId, hoksEid, tutkinnonOsaTyyppi } = this.props
+    if (moduleId && hoksEid && tutkinnonOsaTyyppi) {
       navigate(
         `${window.location.pathname}?${stringifyShareParams({
           moduleId,
           type: "osaamisenhankkimistapa",
           tutkinnonOsaTyyppi,
-          tutkinnonOsaModuleId: moduleId
+          tutkinnonOsaModuleId: moduleId,
+          hoksEid: hoksEid
         })}`
       )
     }

--- a/shared/components/TutkinnonOsa.tsx
+++ b/shared/components/TutkinnonOsa.tsx
@@ -226,7 +226,7 @@ export class TutkinnonOsa extends React.Component<
           type: "osaamisenhankkimistapa",
           tutkinnonOsaTyyppi,
           tutkinnonOsaModuleId: moduleId,
-          hoksEid: hoksEid
+          hoksEid
         })}`
       )
     }
@@ -250,6 +250,7 @@ export class TutkinnonOsa extends React.Component<
       osaamisenHankkimistavat = [],
       koodiUri,
       moduleId,
+      hoksEid,
       tutkinnonOsaTyyppi,
       share,
       title,
@@ -267,7 +268,7 @@ export class TutkinnonOsa extends React.Component<
       osaamisenOsoittamiset.length > 0 ||
       todentamisenProsessi
     const hasActiveShare =
-      typeof share !== "undefined" && moduleId === share.moduleId
+      typeof share !== "undefined" && moduleId === share.tutkinnonOsaModuleId
     const detailsExpanded = expanded.details || hasActiveShare
 
     return (
@@ -304,6 +305,7 @@ export class TutkinnonOsa extends React.Component<
               todentamisenProsessi={todentamisenProsessi}
               koodiUri={koodiUri}
               share={share}
+              hoksEid={hoksEid}
               moduleId={moduleId}
               tutkinnonOsaTyyppi={tutkinnonOsaTyyppi}
               toggle={this.toggle}

--- a/shared/components/TutkinnonOsa/Details.tsx
+++ b/shared/components/TutkinnonOsa/Details.tsx
@@ -132,7 +132,6 @@ const ExpandIcon = ({
   ) : null
 
 const OsaamisenHankkimistavatExpanded = ({
-  hasActiveShare,
   fadedColor,
   shareModuleId,
   hoksEid,
@@ -141,7 +140,6 @@ const OsaamisenHankkimistavatExpanded = ({
   instructor,
   osaamisenHankkimistavat
 }: {
-  hasActiveShare: boolean
   fadedColor: string
   shareModuleId?: string
   hoksEid?: string
@@ -171,7 +169,7 @@ const OsaamisenHankkimistavatExpanded = ({
         <OsaamisenHankkimistapa
           key={i}
           osaamisenHankkimistapa={osaamisenHankkimistapa}
-          hasActiveShare={hasActiveShare}
+          hasActiveShare={osaamisenHankkimistapa.moduleId === shareModuleId}
           moduleId={osaamisenHankkimistapa.moduleId}
           tutkinnonOsaTyyppi={tutkinnonOsaTyyppi}
           tutkinnonOsaModuleId={tutkinnonOsaModuleId}
@@ -206,7 +204,6 @@ const OsaamisenHankkimistavatCollapsed = ({
 
 const OsaamisenOsoittamisetExpanded = ({
   osaamisenOsoittamiset,
-  hasActiveShare,
   fadedColor,
   koodiUri,
   shareModuleId,
@@ -216,7 +213,6 @@ const OsaamisenOsoittamisetExpanded = ({
   todentamisenProsessi
 }: {
   osaamisenOsoittamiset: IOsaamisenOsoittaminen[]
-  hasActiveShare: boolean
   fadedColor: string
   koodiUri?: string
   shareModuleId?: string
@@ -245,9 +241,9 @@ const OsaamisenOsoittamisetExpanded = ({
           osaamisenOsoittaminen={osaamisenOsoittaminen}
           todentamisenProsessi={todentamisenProsessi}
           koodiUri={koodiUri}
-          hasActiveShare={hasActiveShare}
+          hasActiveShare={osaamisenOsoittaminen.moduleId === shareModuleId}
           moduleId={osaamisenOsoittaminen.moduleId}
-          hoksEid={hoksEid}
+          hoksEid={hoksEid || ""}
           tutkinnonOsaTyyppi={tutkinnonOsaTyyppi}
           tutkinnonOsaModuleId={tutkinnonOsaModuleId}
         />
@@ -497,8 +493,8 @@ export class Details extends React.Component<DetailsProps> {
       koodiUri,
       osaamisenHankkimistavat = [],
       share,
-      moduleId,
       hoksEid,
+      moduleId,
       tutkinnonOsaTyyppi,
       toggle,
       todentamisenProsessi,
@@ -516,7 +512,7 @@ export class Details extends React.Component<DetailsProps> {
       !!tarkentavatTiedotOsaamisenArvioija
     const isAiempiOsaaminen = !!todentamisenProsessiKoodi
     // TODO hasActiveShare matches now for koodiUri and might show multiple share modals, should use module-id and check per module
-    const hasActiveShare = moduleId === share?.tutkinnonOsaModuleId
+    const hasActiveShare = moduleId === share?.moduleId
     const shareType = typeof share !== "undefined" ? share.type : undefined
     const firstOsaamisenHankkimistapa =
       shareType === "osaamisenhankkiminen" && osaamisenHankkimistavat[0]
@@ -562,9 +558,6 @@ export class Details extends React.Component<DetailsProps> {
           />
 
           <OsaamisenHankkimistavatExpanded
-            hasActiveShare={
-              hasActiveShare && shareType === "osaamisenhankkiminen"
-            }
             fadedColor={fadedColor}
             instructor={instructor}
             defaultPeriod={defaultPeriod}
@@ -577,9 +570,6 @@ export class Details extends React.Component<DetailsProps> {
 
           <OsaamisenOsoittamisetExpanded
             osaamisenOsoittamiset={osaamisenOsoittamiset}
-            hasActiveShare={
-              hasActiveShare && shareType === "osaamisenosoittaminen"
-            }
             fadedColor={fadedColor}
             koodiUri={koodiUri}
             shareModuleId={share?.moduleId}

--- a/shared/components/TutkinnonOsa/Details.tsx
+++ b/shared/components/TutkinnonOsa/Details.tsx
@@ -135,6 +135,7 @@ const OsaamisenHankkimistavatExpanded = ({
   hasActiveShare,
   fadedColor,
   shareModuleId,
+  hoksEid,
   tutkinnonOsaTyyppi,
   tutkinnonOsaModuleId,
   instructor,
@@ -143,6 +144,7 @@ const OsaamisenHankkimistavatExpanded = ({
   hasActiveShare: boolean
   fadedColor: string
   shareModuleId?: string
+  hoksEid?: string
   tutkinnonOsaTyyppi?: TutkinnonOsaType
   tutkinnonOsaModuleId?: string
   instructor?: Instructor
@@ -154,8 +156,9 @@ const OsaamisenHankkimistavatExpanded = ({
       <ShareDialog
         active={osaamisenHankkimistapa.moduleId === shareModuleId}
         background={fadedColor}
-        type={ShareType.osaamisenhankkimistapa}
+        type={ShareType.osaamisenhankkiminen}
         moduleId={osaamisenHankkimistapa.moduleId || ""}
+        hoksEid={hoksEid || ""}
         defaultPeriod={{
           start: osaamisenHankkimistapa.alku,
           end: osaamisenHankkimistapa.loppu
@@ -172,6 +175,7 @@ const OsaamisenHankkimistavatExpanded = ({
           moduleId={osaamisenHankkimistapa.moduleId}
           tutkinnonOsaTyyppi={tutkinnonOsaTyyppi}
           tutkinnonOsaModuleId={tutkinnonOsaModuleId}
+          hoksEid={hoksEid}
         />
       </ShareDialog>
     ))}
@@ -206,6 +210,7 @@ const OsaamisenOsoittamisetExpanded = ({
   fadedColor,
   koodiUri,
   shareModuleId,
+  hoksEid,
   tutkinnonOsaTyyppi,
   tutkinnonOsaModuleId,
   todentamisenProsessi
@@ -215,6 +220,7 @@ const OsaamisenOsoittamisetExpanded = ({
   fadedColor: string
   koodiUri?: string
   shareModuleId?: string
+  hoksEid?: string
   tutkinnonOsaTyyppi?: TutkinnonOsaType
   tutkinnonOsaModuleId?: string
   todentamisenProsessi?: TodentamisenProsessi
@@ -226,6 +232,7 @@ const OsaamisenOsoittamisetExpanded = ({
         background={fadedColor}
         type={ShareType.osaamisenosoittaminen}
         moduleId={osaamisenOsoittaminen.moduleId || ""}
+        hoksEid={hoksEid || ""}
         defaultPeriod={{
           start: osaamisenOsoittaminen.alku,
           end: osaamisenOsoittaminen.loppu
@@ -240,6 +247,7 @@ const OsaamisenOsoittamisetExpanded = ({
           koodiUri={koodiUri}
           hasActiveShare={hasActiveShare}
           moduleId={osaamisenOsoittaminen.moduleId}
+          hoksEid={hoksEid}
           tutkinnonOsaTyyppi={tutkinnonOsaTyyppi}
           tutkinnonOsaModuleId={tutkinnonOsaModuleId}
         />
@@ -464,6 +472,7 @@ interface DetailsProps {
     moduleId?: string
     tutkinnonOsaTyyppi?: TutkinnonOsaType
     tutkinnonOsaModuleId?: string
+    hoksEid?: string
   }
   toggle: (name: ToggleableItems) => () => void
   todentamisenProsessi?: TodentamisenProsessi
@@ -471,6 +480,7 @@ interface DetailsProps {
   tarkentavatTiedotOsaamisenArvioija?: ITarkentavatTiedotOsaamisenArvioija
   moduleId?: string
   tutkinnonOsaTyyppi?: TutkinnonOsaType
+  hoksEid?: string
 }
 
 export class Details extends React.Component<DetailsProps> {
@@ -488,6 +498,7 @@ export class Details extends React.Component<DetailsProps> {
       osaamisenHankkimistavat = [],
       share,
       moduleId,
+      hoksEid,
       tutkinnonOsaTyyppi,
       toggle,
       todentamisenProsessi,
@@ -508,7 +519,7 @@ export class Details extends React.Component<DetailsProps> {
     const hasActiveShare = moduleId === share?.tutkinnonOsaModuleId
     const shareType = typeof share !== "undefined" ? share.type : undefined
     const firstOsaamisenHankkimistapa =
-      shareType === "osaamisenhankkimistapa" && osaamisenHankkimistavat[0]
+      shareType === "osaamisenhankkiminen" && osaamisenHankkimistavat[0]
         ? osaamisenHankkimistavat[0]
         : undefined
 
@@ -552,7 +563,7 @@ export class Details extends React.Component<DetailsProps> {
 
           <OsaamisenHankkimistavatExpanded
             hasActiveShare={
-              hasActiveShare && shareType === "osaamisenhankkimistapa"
+              hasActiveShare && shareType === "osaamisenhankkiminen"
             }
             fadedColor={fadedColor}
             instructor={instructor}
@@ -561,6 +572,7 @@ export class Details extends React.Component<DetailsProps> {
             tutkinnonOsaTyyppi={tutkinnonOsaTyyppi}
             tutkinnonOsaModuleId={moduleId}
             shareModuleId={share?.moduleId}
+            hoksEid={hoksEid}
           />
 
           <OsaamisenOsoittamisetExpanded
@@ -571,6 +583,7 @@ export class Details extends React.Component<DetailsProps> {
             fadedColor={fadedColor}
             koodiUri={koodiUri}
             shareModuleId={share?.moduleId}
+            hoksEid={hoksEid}
             tutkinnonOsaTyyppi={tutkinnonOsaTyyppi}
             tutkinnonOsaModuleId={moduleId}
             todentamisenProsessi={todentamisenProsessi}

--- a/shared/components/TutkinnonOsa/OsaamisenHankkimistapa.tsx
+++ b/shared/components/TutkinnonOsa/OsaamisenHankkimistapa.tsx
@@ -65,6 +65,7 @@ const FlexLearningEvent = styled(LearningEvent)`
 interface OsaamisenHankkimistapaProps {
   osaamisenHankkimistapa: IOsaamisenHankkimistapa
   moduleId?: string
+  hoksEid?: string
   hasActiveShare?: boolean
   tutkinnonOsaTyyppi?: TutkinnonOsaType
   tutkinnonOsaModuleId?: string
@@ -77,12 +78,18 @@ export class OsaamisenHankkimistapa extends React.Component<
   static contextType = AppContext
   declare context: React.ContextType<typeof AppContext>
   share = () => {
-    const { moduleId, tutkinnonOsaTyyppi, tutkinnonOsaModuleId } = this.props
-    if (moduleId && tutkinnonOsaTyyppi && tutkinnonOsaModuleId) {
+    const {
+      moduleId,
+      hoksEid,
+      tutkinnonOsaTyyppi,
+      tutkinnonOsaModuleId
+    } = this.props
+    if (moduleId && hoksEid && tutkinnonOsaTyyppi && tutkinnonOsaModuleId) {
       navigate(
         `${window.location.pathname}?${stringifyShareParams({
           type: "osaamisenhankkimistapa",
           moduleId,
+          hoksEid,
           tutkinnonOsaTyyppi,
           tutkinnonOsaModuleId
         })}`

--- a/shared/components/TutkinnonOsa/OsaamisenOsoittaminen.tsx
+++ b/shared/components/TutkinnonOsa/OsaamisenOsoittaminen.tsx
@@ -73,6 +73,7 @@ interface OsaamisenOsoittaminenProps {
   osaamisenOsoittaminen: IOsaamisenOsoittaminen
   todentamisenProsessi?: TodentamisenProsessi
   moduleId?: string
+  hoksEid?: string
   koodiUri?: string
   hasActiveShare?: boolean
   tutkinnonOsaTyyppi?: TutkinnonOsaType
@@ -98,12 +99,18 @@ export class OsaamisenOsoittaminen extends React.Component<
   }
 
   share = () => {
-    const { moduleId, tutkinnonOsaTyyppi, tutkinnonOsaModuleId } = this.props
-    if (moduleId && tutkinnonOsaTyyppi && tutkinnonOsaModuleId) {
+    const {
+      moduleId,
+      hoksEid,
+      tutkinnonOsaTyyppi,
+      tutkinnonOsaModuleId
+    } = this.props
+    if (moduleId && hoksEid && tutkinnonOsaTyyppi && tutkinnonOsaModuleId) {
       navigate(
         `${window.location.pathname}?${stringifyShareParams({
           type: "osaamisenosoittaminen",
           moduleId,
+          hoksEid,
           tutkinnonOsaTyyppi,
           tutkinnonOsaModuleId
         })}`

--- a/shared/models/helpers/ShareTypes.ts
+++ b/shared/models/helpers/ShareTypes.ts
@@ -1,6 +1,6 @@
 export enum ShareType {
   "osaamisenosoittaminen" = "osaamisenosoittaminen",
-  "osaamisenhankkimistapa" = "osaamisenhankkimistapa"
+  "osaamisenhankkiminen" = "osaamisenhankkiminen"
 }
 
 export enum TutkinnonOsaType {

--- a/shared/utils/shareParams.ts
+++ b/shared/utils/shareParams.ts
@@ -10,6 +10,7 @@ export function parseShareParams(
     moduleId: string | ""
     tutkinnonOsaTyyppi?: TutkinnonOsaType
     tutkinnonOsaModuleId: string | ""
+    hoksEid: string | ""
   }
 } {
   const qs = queryString.parse(location ? location.search : "")
@@ -24,7 +25,8 @@ export function parseShareParams(
       tutkinnonOsaModuleId:
         typeof qs.tutkinnonOsaModuleId === "string"
           ? qs.tutkinnonOsaModuleId
-          : ""
+          : "",
+      hoksEid: typeof qs.hoksEid === "string" ? qs.hoksEid : ""
     }
   }
 }
@@ -33,16 +35,19 @@ export const stringifyShareParams = ({
   type,
   moduleId,
   tutkinnonOsaTyyppi,
-  tutkinnonOsaModuleId
+  tutkinnonOsaModuleId,
+  hoksEid
 }: {
   type: string
   moduleId: string
   tutkinnonOsaTyyppi: TutkinnonOsaType
   tutkinnonOsaModuleId: string
+  hoksEid: string
 }): string =>
   queryString.stringify({
     type,
     moduleId,
     tutkinnonOsaTyyppi,
-    tutkinnonOsaModuleId
+    tutkinnonOsaModuleId,
+    hoksEid
   })


### PR DESCRIPTION
Tässä pr:ssä korjattu
- hoks-eid tiputellaan propsina kohti ShareDialogia
- lähetetään oikeat tiedot bäkkäriin linkkiä luodessa
- korjattiin luodun linkin poistamisen nappu ja lähetettävät tiedot