### PR TITLE
Deleted unused login funtion

### DIFF
--- a/virkailija/src/stores/SessionStore.ts
+++ b/virkailija/src/stores/SessionStore.ts
@@ -1,6 +1,5 @@
 import { withQueryString } from "fetchUtils"
 import { flow, getEnv, Instance, types } from "mobx-state-tree"
-import { APIResponse } from "types/APIResponse"
 import { IOrganisation, OrganisationModel } from "types/Organisation"
 import { StoreEnvironment } from "types/StoreEnvironment"
 
@@ -32,25 +31,10 @@ export const SessionStore = types
       apiUrl,
       fetchSingle,
       fetchCollection,
-      fetch,
       deleteResource,
       errors,
       callerId
     } = getEnv<StoreEnvironment>(self)
-
-    const login = flow(function*(url: string): any {
-      self.isLoading = true
-      try {
-        const response: APIResponse = yield fetch(url, {
-          mode: "no-cors",
-          headers: callerId()
-        })
-        self.user = response.data
-      } catch (error) {
-        self.error = error.message
-      }
-      self.isLoading = false
-    })
 
     const checkSession = flow(function*(): any {
       self.isLoading = true
@@ -119,7 +103,6 @@ export const SessionStore = types
 
     return {
       checkSession,
-      login,
       logout,
       resetUserDidLogout,
       changeSelectedOrganisationOid


### PR DESCRIPTION
Poistettu virkailijan sessionStoresta login funktio jota ei enää käytetty. Oli aiemmin käytössä mutta PR:ssä https://github.com/Opetushallitus/ehoks-ui/pull/48 muutettiin redirectiksi login urliin.