### PR TITLE
Eh 981 komponentti linkinjakoon

### DIFF
--- a/oppija/public/ehoks/piwik.js
+++ b/oppija/public/ehoks/piwik.js
@@ -23,6 +23,9 @@ switch (siteDomain) {
   case "testiopintopolku.fi":
     piwikSiteId = 23
     break
+  case "testistudieinfo.fi":
+    piwikSiteId = 23
+    break
   default:
     piwikSiteId = "" // Kehitys
 }

--- a/oppija/src/index.tsx
+++ b/oppija/src/index.tsx
@@ -2,7 +2,7 @@ import { APIConfigContext } from "components/APIConfigContext"
 import { AppContext } from "components/AppContext"
 import { apiPrefix, apiUrl } from "config"
 import { createEnvironment } from "createEnvironment"
-import { callerId, fetch } from "fetchUtils"
+import { appendCallerId, fetch } from "fetchUtils"
 import { Provider } from "mobx-react"
 import "promise-polyfill/src/polyfill" // polyfill Promise for IE 11
 import React from "react"
@@ -19,7 +19,7 @@ addLocaleData([...fi, ...sv])
 // pass fetch utils to RootStore using MST's environment context, so we can easily mock it in tests
 const store = RootStore.create(
   {},
-  createEnvironment(fetch, apiUrl, apiPrefix, callerId)
+  createEnvironment(fetch, apiUrl, apiPrefix, appendCallerId)
 )
 store.environment.getEnvironment()
 store.translations.fetchLocales()

--- a/oppija/src/routes/App.tsx
+++ b/oppija/src/routes/App.tsx
@@ -23,7 +23,6 @@ import { Suunnittelu } from "routes/Suunnittelu"
 import { IRootStore } from "stores/RootStore"
 import { Locale } from "stores/TranslationStore"
 import styled from "styled"
-import { AppContext } from "components/AppContext"
 
 const Container = styled("div")`
   margin: 0;
@@ -62,12 +61,8 @@ export interface AppProps {
 @inject("store")
 @observer
 export class App extends React.Component<AppProps> {
-  static contextType = AppContext
-  declare context: React.ContextType<typeof AppContext>
-
   async componentDidMount() {
     const { store } = this.props
-    const { featureFlags } = this.context
     const localeParam = parseLocaleParam(window.location.search)
     if (localeParam) {
       store!.translations.setActiveLocale(localeParam)
@@ -79,19 +74,8 @@ export class App extends React.Component<AppProps> {
       store!.translations.setActiveLocale(locale)
     }
 
-    const sessionStore = store!.session
-    if (featureFlags.casOppija) {
-      try {
-        await sessionStore.checkSession()
-      } finally {
-        if (!sessionStore.isLoggedIn) {
-          window.location.href = store!.environment.casOppijaLoginUrl
-        }
-      }
-    } else {
-      // load user session info from backend
-      await sessionStore.checkSession()
-    }
+    // load user session info from backend
+    await store!.session.checkSession()
   }
 
   render() {

--- a/oppija/src/routes/Etusivu.tsx
+++ b/oppija/src/routes/Etusivu.tsx
@@ -13,6 +13,7 @@ import { Locale } from "stores/TranslationStore"
 import styled from "styled"
 import ammatillisetTutkinnotImage from "./Etusivu/kampaaja_ehoks.jpg"
 import henkilokohtaistaminenImage from "./Etusivu/talonrakennus_ehoks.jpg"
+import { AppContext } from "components/AppContext"
 
 const LoginBoxes = styled("div")`
   display: flex;
@@ -121,6 +122,8 @@ export interface EtusivuProps extends RouteComponentProps {
 @observer
 export class Etusivu extends React.Component<EtusivuProps> {
   disposeLoginReaction: IReactionDisposer
+  static contextType = AppContext
+  declare context: React.ContextType<typeof AppContext>
 
   componentDidMount() {
     const { store } = this.props
@@ -140,11 +143,20 @@ export class Etusivu extends React.Component<EtusivuProps> {
 
   loginStudent = (event: React.MouseEvent) => {
     event.preventDefault()
-    this.props.store!.session.resetUserDidLogout()
-    window.location.href =
-      this.props.store!.translations.activeLocale === Locale.SV
-        ? this.props.store!.environment.opintopolkuLoginUrlSv
-        : this.props.store!.environment.opintopolkuLoginUrlFi
+    const store = this.props.store
+    const { featureFlags } = this.context
+    store!.session.resetUserDidLogout()
+
+    if (featureFlags.casOppija) {
+      if (!store!.session.isLoggedIn) {
+        window.location.href = store!.environment.casOppijaLoginUrl
+      }
+    } else {
+      window.location.href =
+        store!.translations.activeLocale === Locale.SV
+          ? store!.environment.opintopolkuLoginUrlSv
+          : store!.environment.opintopolkuLoginUrlFi
+    }
   }
 
   loginVirkailija = (event: React.MouseEvent) => {

--- a/oppija/src/stores/EducationProviderStore.ts
+++ b/oppija/src/stores/EducationProviderStore.ts
@@ -14,13 +14,15 @@ const EducationProviderModel = {
 export const EducationProviderStore = types
   .model("EducationProviderStore", EducationProviderModel)
   .actions(self => {
-    const { fetchSingle, apiUrl, callerId } = getEnv<StoreEnvironment>(self)
+    const { fetchSingle, apiUrl, appendCallerId } = getEnv<StoreEnvironment>(
+      self
+    )
 
     const fetchInfo = flow(function*(): any {
       self.isLoading = true
       const response: APIResponse<IEducationProviderInfo> = yield fetchSingle(
         apiUrl("education/info/"),
-        { headers: callerId() }
+        { headers: appendCallerId() }
       )
       self.info = response.data
       self.isLoading = false

--- a/oppija/src/stores/EnvironmentStore.ts
+++ b/oppija/src/stores/EnvironmentStore.ts
@@ -22,7 +22,7 @@ const EnvironmentStoreModel = {
 export const EnvironmentStore = types
   .model("EnvironmentStore", EnvironmentStoreModel)
   .actions(self => {
-    const { apiUrl, fetchSingle, fetch, errors, callerId } = getEnv<
+    const { apiUrl, fetchSingle, fetch, errors, appendCallerId } = getEnv<
       StoreEnvironment
     >(self)
 
@@ -31,7 +31,7 @@ export const EnvironmentStore = types
       try {
         const response: APIResponse = yield fetchSingle(
           apiUrl("misc/environment"),
-          { headers: callerId() }
+          { headers: appendCallerId() }
         )
         const {
           eperusteetPerusteUrl,

--- a/oppija/src/stores/EnvironmentStore.ts
+++ b/oppija/src/stores/EnvironmentStore.ts
@@ -39,7 +39,8 @@ export const EnvironmentStore = types
           opintopolkuLoginUrlSv,
           opintopolkuLogoutUrlFi,
           opintopolkuLogoutUrlSv,
-          virkailijaLoginUrl
+          virkailijaLoginUrl,
+          casOppijaLoginUrl
         } = response.data
         self.eperusteetPerusteUrl = eperusteetPerusteUrl
         self.opintopolkuLoginUrlFi = devBackendWithoutHost(
@@ -55,6 +56,7 @@ export const EnvironmentStore = types
           opintopolkuLogoutUrlSv
         )
         self.virkailijaLoginUrl = virkailijaLoginUrl
+        self.casOppijaLoginUrl = devBackendWithoutHost(casOppijaLoginUrl)
       } catch (error) {
         errors.logError("EnvironmentStore.getEnvironment", error.message)
       }

--- a/oppija/src/stores/HOKSStore.ts
+++ b/oppija/src/stores/HOKSStore.ts
@@ -44,7 +44,7 @@ export const HOKSStore = types
   }))
   .actions(self => {
     const root: IRootStore = getRoot(self)
-    const { apiUrl, fetchCollection, errors, callerId } = getEnv<
+    const { apiUrl, fetchCollection, errors, appendCallerId } = getEnv<
       StoreEnvironment
     >(self)
 
@@ -53,7 +53,7 @@ export const HOKSStore = types
       try {
         const response: APIResponse = yield fetchCollection(
           apiUrl(`oppija/oppijat/${oid}/hoks`),
-          { headers: callerId() }
+          { headers: appendCallerId() }
         )
         self.suunnitelmat = response.data
 

--- a/oppija/src/stores/OppilasStore.ts
+++ b/oppija/src/stores/OppilasStore.ts
@@ -11,7 +11,7 @@ const OppilasStoreModel = {
 export const OppilasStore = types
   .model("OppilasStore", OppilasStoreModel)
   .actions(self => {
-    const { apiUrl, fetchCollection, errors, callerId } = getEnv<
+    const { apiUrl, fetchCollection, errors, appendCallerId } = getEnv<
       StoreEnvironment
     >(self)
     // tracks the most recent fetch by user
@@ -22,7 +22,7 @@ export const OppilasStore = types
       try {
         const fetchPromise: Promise<APIResponse> = fetchCollection(
           apiUrl(`external/eperusteet/?nimi=${name}`),
-          { headers: callerId() }
+          { headers: appendCallerId() }
         )
         newestPromise = fetchPromise
         const response = yield fetchPromise

--- a/oppija/src/stores/SessionStore.ts
+++ b/oppija/src/stores/SessionStore.ts
@@ -16,16 +16,20 @@ const SessionStoreModel = {
 export const SessionStore = types
   .model("SessionStore", SessionStoreModel)
   .actions(self => {
-    const { apiUrl, fetchSingle, deleteResource, errors, callerId } = getEnv<
-      StoreEnvironment
-    >(self)
+    const {
+      apiUrl,
+      fetchSingle,
+      deleteResource,
+      errors,
+      appendCallerId
+    } = getEnv<StoreEnvironment>(self)
 
     const checkSession = flow(function*(): any {
       self.isLoading = true
       try {
         const response: APIResponse = yield fetchSingle(
           apiUrl("oppija/session"),
-          { headers: callerId() }
+          { headers: appendCallerId() }
         )
         self.user = response.data
       } catch (error) {
@@ -46,7 +50,7 @@ export const SessionStore = types
       try {
         const response: APIResponse = yield fetchSingle(
           apiUrl("oppija/session/user-info"),
-          { headers: callerId() }
+          { headers: appendCallerId() }
         )
         self.user = response.data
       } catch (error) {
@@ -58,7 +62,7 @@ export const SessionStore = types
       try {
         const response: APIResponse = yield fetchSingle(
           apiUrl("oppija/session/settings"),
-          { headers: callerId() }
+          { headers: appendCallerId() }
         )
         self.settings = response.data
       } catch (error) {
@@ -71,7 +75,9 @@ export const SessionStore = types
         yield fetchSingle(apiUrl("oppija/session/settings"), {
           method: "put",
           body: JSON.stringify(getSnapshot(self.settings)),
-          headers: callerId(new Headers({ "Content-Type": "application/json" }))
+          headers: appendCallerId(
+            new Headers({ "Content-Type": "application/json" })
+          )
         })
       } catch (error) {
         errors.logError("SessionStore.saveSettings", error.message)
@@ -81,7 +87,9 @@ export const SessionStore = types
     const logout = flow(function*() {
       self.isLoading = true
       try {
-        yield deleteResource(apiUrl("oppija/session"), { headers: callerId() })
+        yield deleteResource(apiUrl("oppija/session"), {
+          headers: appendCallerId()
+        })
         self.user = undefined
         self.userDidLogout = true
         self.isLoading = false

--- a/oppija/translations.json
+++ b/oppija/translations.json
@@ -193,6 +193,7 @@
     "opiskelusuunnitelma.osaamisalaTitle": "Osaamisala",
     "opiskelusuunnitelma.osaamispisteLyhenne": "osp",
     "opiskelusuunnitelma.osaamispistettaPostfix": "osaamispistettä",
+    "opiskelusuunnitelma.osaamistavoitteetTitle": "Osaamistavoitteet",
     "opiskelusuunnitelma.piilotaAmmattitaitovaatimuksetAriaLabel": "Piilota ammattitaitovaatimukset ja arviointikriteerit",
     "opiskelusuunnitelma.piilotaKaikkiKriteeritLink": "Piilota arviointikriteerit",
     "opiskelusuunnitelma.piilotaKriteeritLink": "Piilota arviointikriteerit",

--- a/oppija/webpack.config.js
+++ b/oppija/webpack.config.js
@@ -29,6 +29,7 @@ module.exports = {
     inline: true,
     proxy: {
       "/auth-dev": "http://localhost:3000",
+      "/cas-oppija": "http://localhost:3000",
       "/ehoks-oppija-backend": "http://localhost:3000"
     }
   },

--- a/shared/components/ShareDialog.tsx
+++ b/shared/components/ShareDialog.tsx
@@ -219,7 +219,9 @@ export function ShareDialog(props: ShareDialogProps) {
         apiConfig
       })
       setSharedLinks(await fetchLinks(moduleId, apiConfig))
-      setCreatedUrl(`https://not.implemented.yet/jako/${createdUuid}`)
+      setCreatedUrl(
+        `${window.location.origin}/ehoks-tyopaikantoimija-ui/${createdUuid}`
+      )
     }
   }
 

--- a/shared/components/ShareDialog/API.ts
+++ b/shared/components/ShareDialog/API.ts
@@ -16,7 +16,6 @@ export interface ShareLink {
   validTo: string
   type: string
 }
-
 export const fetchLinks = async function(
   moduleId: string,
   apiConfig: APIConfig

--- a/shared/components/ShareDialog/API.ts
+++ b/shared/components/ShareDialog/API.ts
@@ -1,5 +1,6 @@
 import { APIConfig } from "components/APIConfigContext"
 import { TutkinnonOsaType } from "../../models/helpers/ShareTypes"
+import { appendCallerId } from "../../fetchUtils"
 
 interface BackendShareLink {
   "share-id": string
@@ -24,6 +25,7 @@ export const fetchLinks = async function(
   const response = await window.fetch(
     apiUrl(`${apiPrefix}/jaot/moduulit/${moduleId}`),
     {
+      headers: appendCallerId(),
       credentials: "include"
     }
   )
@@ -62,9 +64,11 @@ export const createLink = async function({
   const response = await window.fetch(apiUrl(`${apiPrefix}/jaot/jakolinkit`), {
     credentials: "include",
     method: "POST",
-    headers: {
-      "Content-Type": "application/json"
-    },
+    headers: appendCallerId(
+      new Headers({
+        "Content-Type": "application/json"
+      })
+    ),
     body: JSON.stringify({
       "tutkinnonosa-module-uuid": tutkinnonOsaModuleId,
       "tutkinnonosa-tyyppi": tutkinnonOsaTyyppi,
@@ -96,9 +100,11 @@ export const removeLink = async function({
     {
       credentials: "include",
       method: "DELETE",
-      headers: {
-        "Content-Type": "application/json"
-      }
+      headers: appendCallerId(
+        new Headers({
+          "Content-Type": "application/json"
+        })
+      )
     }
   )
 

--- a/shared/components/ShareLinkInfo.tsx
+++ b/shared/components/ShareLinkInfo.tsx
@@ -1,0 +1,81 @@
+import React from "react"
+import { FormattedMessage } from "react-intl"
+import { Container } from "components/Container"
+import { Share } from "../../tyopaikantoimija/src/stores/ShareStore"
+import { Instance } from "mobx-state-tree"
+import { TutkinnonOsa } from "components/TutkinnonOsa"
+import { StudiesContainer } from "components/StudiesContainer"
+import { FormattedDate } from "components/FormattedDate"
+import styled from "styled"
+
+interface ShareLinkInfoProps {
+  share: Instance<typeof Share>
+}
+
+const ShareTitle = styled("h1")`
+  margin: 0 0 16px 0;
+`
+
+const ShareSubTitle = styled("h2")`
+  margin: 0 0 16px 0;
+`
+
+export function ShareLinkInfo(props: ShareLinkInfoProps) {
+  const { share } = props
+
+  return (
+    <React.Fragment>
+      <Container>
+        <Container>
+          <ShareTitle>
+            <FormattedMessage
+              id="tyopaikantoimija.oppijanTiedot"
+              defaultMessage="{nimi}, {tutkintoNimi} "
+              values={{
+                nimi: share.oppijaNimi,
+                tutkintoNimi: share.tutkintoNimi.fi
+              }}
+            />
+          </ShareTitle>
+        </Container>
+        <Container>
+          <ShareSubTitle>
+            <FormattedMessage
+              id="tyopaikantoimija.linkinTiedot"
+              defaultMessage="Työpaikalla oppimisen tiedot on jaettuna sinulle
+            {voimassaoloAlku}-{voimassaoloLoppu} "
+              values={{
+                voimassaoloAlku: <FormattedDate date={share.voimassaoloAlku} />,
+                voimassaoloLoppu: (
+                  <FormattedDate date={share.voimassaoloLoppu} />
+                )
+              }}
+            />
+          </ShareSubTitle>
+        </Container>
+        <Container>
+          {(share.osaamisenHankkimistapa || share.osaamisenOsoittaminen) && (
+            <StudiesContainer>
+              <TutkinnonOsa
+                accentColor="scheduled"
+                title={"Tähän tarvitaan otsikko"}
+                share={{ moduleId: share.tutkinnonosa?.moduleId }}
+                koodiUri={share.tutkinnonosa?.tutkinnonOsaKoodiUri}
+                osaamisenHankkimistavat={
+                  share.osaamisenHankkimistapa
+                    ? [share.osaamisenHankkimistapa]
+                    : []
+                }
+                osaamisenOsoittamiset={
+                  share.osaamisenOsoittaminen
+                    ? [share.osaamisenOsoittaminen]
+                    : []
+                }
+              />
+            </StudiesContainer>
+          )}
+        </Container>
+      </Container>
+    </React.Fragment>
+  )
+}

--- a/shared/components/TutkinnonOsa/Competences.tsx
+++ b/shared/components/TutkinnonOsa/Competences.tsx
@@ -136,10 +136,18 @@ export class Competences extends React.Component<CompetencesProps> {
             <CollapseContainer data-testid="TutkinnonOsa.Competences.CollapseContainer">
               <CollapseHeaderContainer>
                 <CollapseHeader>
-                  <FormattedMessage
-                    id="opiskelusuunnitelma.ammattitaitovaatimuksetTitle"
-                    defaultMessage="Ammattitaitovaatimukset"
-                  />
+                  {tutkinnonOsaTyyppi ===
+                  TutkinnonOsaType.HankittavanYhteisenTutkinnonOsanOsaAlue ? (
+                    <FormattedMessage
+                      id="opiskelusuunnitelma.osaamistavoitteetTitle"
+                      defaultMessage="Osaamistavoitteet"
+                    />
+                  ) : (
+                    <FormattedMessage
+                      id="opiskelusuunnitelma.ammattitaitovaatimuksetTitle"
+                      defaultMessage="Ammattitaitovaatimukset"
+                    />
+                  )}
                 </CollapseHeader>
                 <ToggleAllTitle onClick={allExpanded ? collapseAll : expandAll}>
                   {allExpanded ? (

--- a/shared/createEnvironment.ts
+++ b/shared/createEnvironment.ts
@@ -6,11 +6,11 @@ export const createEnvironment = (
   fetchFn: WindowOrWorkerGlobalScope["fetch"],
   apiUrl: (path: string) => string,
   apiPrefix: string,
-  callerId: (headers?: Headers) => Headers
+  appendCallerId: (headers?: Headers) => Headers
 ): StoreEnvironment => ({
   ...fetchUtils(fetchFn),
   errors: ErrorStore.create({}),
   apiUrl,
   apiPrefix,
-  callerId
+  appendCallerId
 })

--- a/shared/fetchUtils.ts
+++ b/shared/fetchUtils.ts
@@ -124,7 +124,7 @@ export const mockFetch = (apiUrl: (path: string) => string, version = 0) => (
 export const fetch = (url: string | Request, init: RequestInit) =>
   window.fetch(url, { credentials: "include", ...init })
 
-export const callerId = (headers?: Headers) => {
+export const appendCallerId = (headers?: Headers) => {
   if (headers) {
     headers.append("Caller-Id", "1.2.246.562.10.00000000001.ehoks.ehoks-ui")
     return headers

--- a/shared/models/Enrichment/EnrichKoodistoKoodiUri.ts
+++ b/shared/models/Enrichment/EnrichKoodistoKoodiUri.ts
@@ -21,7 +21,7 @@ export const EnrichKoodistoKoodiUri = (
     // when assigning to self[enrichedField]
     .volatile((): DynamicObject => ({}))
     .actions(self => {
-      const { apiUrl, apiPrefix, errors, fetchSingle, callerId } = getEnv<
+      const { apiUrl, apiPrefix, errors, fetchSingle, appendCallerId } = getEnv<
         StoreEnvironment
       >(self)
 
@@ -38,7 +38,7 @@ export const EnrichKoodistoKoodiUri = (
 
       const getFromKoodistoService = (koodiUri: string) =>
         fetchSingle(apiUrl(`${apiPrefix}/external/koodisto/${koodiUri}`), {
-          headers: callerId()
+          headers: appendCallerId()
         })
 
       const parseResponse = (data: any) =>

--- a/shared/models/Enrichment/EnrichOrganisaatioOid.ts
+++ b/shared/models/Enrichment/EnrichOrganisaatioOid.ts
@@ -21,7 +21,7 @@ export const EnrichOrganisaatioOid = (
     // when assigning to self[dynamicKey]
     .volatile((): DynamicObject => ({}))
     .actions(self => {
-      const { apiUrl, apiPrefix, errors, fetchSingle, callerId } = getEnv<
+      const { apiUrl, apiPrefix, errors, fetchSingle, appendCallerId } = getEnv<
         StoreEnvironment
       >(self)
 
@@ -40,7 +40,7 @@ export const EnrichOrganisaatioOid = (
         fetchSingle(
           apiUrl(`${apiPrefix}/external/organisaatio/${organisaatioOid}`),
           {
-            headers: callerId()
+            headers: appendCallerId()
           }
         )
 

--- a/shared/models/Enrichment/EnrichTutkinnonOsaAndOsaAlueet.ts
+++ b/shared/models/Enrichment/EnrichTutkinnonOsaAndOsaAlueet.ts
@@ -23,12 +23,12 @@ export const EnrichTutkinnonOsaAndOsaAlueet = types
       errors,
       fetchSingle,
       fetchCollection,
-      callerId
+      appendCallerId
     } = getEnv<StoreEnvironment>(self)
 
     const getTutkinnonOsaFromEPerusteet = (code: string) =>
       fetchSingle(apiUrl(`${apiPrefix}/external/eperusteet/${code}`), {
-        headers: callerId()
+        headers: appendCallerId()
       })
 
     const fetchTutkinnonOsa = flow(function*(koodiUri: string): any {
@@ -52,7 +52,7 @@ export const EnrichTutkinnonOsaAndOsaAlueet = types
           `${apiPrefix}/external/eperusteet/tutkinnonosat/${tutkinnonOsaId}/osaalueet`
         ),
         {
-          headers: callerId()
+          headers: appendCallerId()
         }
       )
 

--- a/shared/models/Enrichment/EnrichTutkinnonOsaKoodiUri.ts
+++ b/shared/models/Enrichment/EnrichTutkinnonOsaKoodiUri.ts
@@ -15,13 +15,13 @@ export const EnrichTutkinnonOsaKoodiUri = types
   // when assigning to self[dynamicKey]
   .volatile((): DynamicObject => ({}))
   .actions(self => {
-    const { apiUrl, apiPrefix, errors, fetchSingle, callerId } = getEnv<
+    const { apiUrl, apiPrefix, errors, fetchSingle, appendCallerId } = getEnv<
       StoreEnvironment
     >(self)
 
     const getFromEPerusteetService = (code: string) =>
       fetchSingle(apiUrl(`${apiPrefix}/external/eperusteet/${code}`), {
-        headers: callerId()
+        headers: appendCallerId()
       })
 
     const fetchEPerusteet = flow(function*(koodiUri: string): any {

--- a/shared/models/Enrichment/EnrichTutkinnonOsaViitteet.ts
+++ b/shared/models/Enrichment/EnrichTutkinnonOsaViitteet.ts
@@ -18,16 +18,21 @@ export const EnrichTutkinnonOsaViitteet = (
       })
     )
     .actions(self => {
-      const { apiUrl, apiPrefix, errors, fetchCollection } = getEnv<
-        StoreEnvironment
-      >(self)
+      const {
+        apiUrl,
+        apiPrefix,
+        errors,
+        fetchCollection,
+        appendCallerId
+      } = getEnv<StoreEnvironment>(self)
 
       const fetchTutkinnonOsaViitteet = flow(function*(id: number): any {
         try {
           const response: APIResponse = yield fetchCollection(
             apiUrl(
               `${apiPrefix}/external/eperusteet/tutkinnonosat/${id}/viitteet`
-            )
+            ),
+            { headers: appendCallerId() }
           )
           if (Object.keys(self).indexOf(fieldName) !== -1) {
             self[fieldName] = response.data

--- a/shared/models/HOKS.ts
+++ b/shared/models/HOKS.ts
@@ -79,14 +79,14 @@ export const HOKS = types
       errors,
       fetchCollection,
       fetchSingle,
-      callerId
+      appendCallerId
     } = getEnv<StoreEnvironment>(self)
 
     // fetches detailed HOKS, only needed in virkailija app
     const fetchDetails = flow(function*(): any {
       const response: APIResponse = yield fetchSingle(
         apiUrl(`${apiPrefix}/oppijat/${self.oppijaOid}/hoksit/${self.id}`),
-        { headers: callerId() }
+        { headers: appendCallerId() }
       )
       const keys = Object.keys(response.data)
       keys.forEach(key => {
@@ -101,7 +101,7 @@ export const HOKS = types
         apiUrl(
           `${apiPrefix}/external/eperusteet/tutkinnot?diaarinumero=${diaarinumero}`
         ),
-        { headers: callerId() }
+        { headers: appendCallerId() }
       )
       const { id, suoritustavat } = response.data
       const suoritustapa = suoritustavat.reduce(
@@ -131,7 +131,7 @@ export const HOKS = types
             suoritustapa === "reformi" ? "rakenne" : "tutkinnonosat"
           }`
         ),
-        { headers: callerId() }
+        { headers: appendCallerId() }
       )
       return response.data
     })
@@ -150,7 +150,7 @@ export const HOKS = types
       try {
         const response = yield fetchCollection(
           apiUrl(`${apiPrefix}/oppijat/${self.oppijaOid}/opiskeluoikeudet`),
-          { headers: callerId() }
+          { headers: appendCallerId() }
         )
         const opiskeluOikeudet: APIResponse = response.data || []
         const opiskeluOikeus = find(

--- a/shared/stores/NotificationStore.ts
+++ b/shared/stores/NotificationStore.ts
@@ -87,7 +87,7 @@ export const NotificationStore = types
     return { addNotifications }
   })
   .actions(self => {
-    const { apiUrl, fetchPrimitiveCollection, errors, callerId } = getEnv<
+    const { apiUrl, fetchPrimitiveCollection, errors, appendCallerId } = getEnv<
       StoreEnvironment
     >(self)
 
@@ -103,7 +103,7 @@ export const NotificationStore = types
       try {
         const response: APIResponse = yield fetchPrimitiveCollection(
           apiUrl(`oppija/oppijat/${oid}/kyselylinkit`),
-          { headers: callerId() }
+          { headers: appendCallerId() }
         )
 
         self.studentFeedbackLinks = response.data

--- a/shared/stores/TranslationStore.ts
+++ b/shared/stores/TranslationStore.ts
@@ -42,9 +42,13 @@ const TranslationStoreModel = {
 export const TranslationStore = types
   .model("TranslationStore", TranslationStoreModel)
   .actions(self => {
-    const { apiUrl, apiPrefix, fetchCollection, errors, callerId } = getEnv<
-      StoreEnvironment
-    >(self)
+    const {
+      apiUrl,
+      apiPrefix,
+      fetchCollection,
+      errors,
+      appendCallerId
+    } = getEnv<StoreEnvironment>(self)
 
     const setActiveLocale = (locale: Locale) => {
       const storedLocale = updateLocaleLocalStorage(locale)
@@ -58,7 +62,7 @@ export const TranslationStore = types
       try {
         const response: APIResponse = yield fetchCollection(
           apiUrl(`${apiPrefix}/external/lokalisointi`),
-          { headers: callerId() }
+          { headers: appendCallerId() }
         )
         // add custom translations from API
         self.translations.replace([

--- a/shared/types/StoreEnvironment.ts
+++ b/shared/types/StoreEnvironment.ts
@@ -5,5 +5,5 @@ export type StoreEnvironment = ReturnType<typeof fetchUtils> & {
   errors: IErrorStore
   apiUrl: (path: string) => string
   apiPrefix: string
-  callerId: (headers?: Headers) => Headers
+  appendCallerId: (headers?: Headers) => Headers
 }

--- a/shared/utils/shareParams.ts
+++ b/shared/utils/shareParams.ts
@@ -51,3 +51,15 @@ export const stringifyShareParams = ({
     tutkinnonOsaModuleId,
     hoksEid
   })
+
+export const parseLinkUuid = (
+  location: WindowLocation | undefined
+): {
+  link: {
+    uuid: string | undefined
+  }
+} => ({
+  link: {
+    uuid: location?.pathname ? location.pathname.split("/").pop() : ""
+  }
+})

--- a/tyopaikantoimija/src/index.tsx
+++ b/tyopaikantoimija/src/index.tsx
@@ -2,7 +2,7 @@ import { APIConfigContext } from "components/APIConfigContext"
 import { AppContext } from "components/AppContext"
 import { apiPrefix, apiUrl } from "config"
 import { createEnvironment } from "createEnvironment"
-import { callerId, fetch } from "fetchUtils"
+import { appendCallerId, fetch } from "fetchUtils"
 import { Provider } from "mobx-react"
 import "promise-polyfill/src/polyfill" // polyfill Promise for IE 11
 import React from "react"
@@ -19,7 +19,7 @@ addLocaleData([...fi, ...sv])
 // pass fetch utils to RootStore using MST's environment context, so we can easily mock it in tests
 const store = RootStore.create(
   {},
-  createEnvironment(fetch, apiUrl, apiPrefix, callerId)
+  createEnvironment(fetch, apiUrl, apiPrefix, appendCallerId)
 )
 store.environment.getEnvironment()
 store.translations.fetchLocales()

--- a/tyopaikantoimija/src/routes/App.tsx
+++ b/tyopaikantoimija/src/routes/App.tsx
@@ -14,9 +14,9 @@ import { AppFooter } from "routes/App/AppFooter"
 import { AppHeader } from "routes/App/AppHeader"
 import { GlobalStyles } from "routes/App/globalStyles"
 import { Etusivu } from "routes/Etusivu"
-import { IRootStore } from "stores/RootStore"
 import { Locale } from "stores/TranslationStore"
 import styled from "styled"
+import { IRootStore } from "../stores/RootStore"
 
 const Container = styled("div")`
   margin: 0;
@@ -31,8 +31,8 @@ const MainApp = (_: RouteComponentProps) => (
   <Container>
     <AppHeader />
     <Main id="main" role="main">
-      <Router basepath="/ehoks-tyopaikantoimija-ui">
-        <Etusivu path="/" />
+      <Router basepath={`/ehoks-tyopaikantoimija-ui`}>
+        <Etusivu path="/:uuid" />
       </Router>
     </Main>
     <AppFooter />

--- a/tyopaikantoimija/src/routes/App/AppHeader.tsx
+++ b/tyopaikantoimija/src/routes/App/AppHeader.tsx
@@ -8,7 +8,7 @@ import { Locale } from "stores/TranslationStore"
 import styled from "styled"
 import ehoksLogo from "./ehoks_logo.png"
 import { LinkButton } from "components/Button"
-import { IRootStore } from "stores/RootStore"
+import { IRootStore } from "../../stores/RootStore"
 
 interface TopLinkProps {
   active?: boolean

--- a/tyopaikantoimija/src/routes/Etusivu.tsx
+++ b/tyopaikantoimija/src/routes/Etusivu.tsx
@@ -1,11 +1,15 @@
 import { RouteComponentProps } from "@reach/router"
-import { Container } from "components/Container"
+import { Container, PaddedContent } from "components/Container"
 import { ContentContainer } from "components/ContentContainer"
+import { MainHeading } from "components/Heading"
 import { inject, observer } from "mobx-react"
 import React from "react"
 import { FormattedMessage } from "react-intl"
-import { IRootStore } from "stores/RootStore"
 import styled from "styled"
+import { ShareLinkInfo } from "components/ShareLinkInfo"
+import { IRootStore } from "../stores/RootStore"
+import { LoadingSpinner } from "components/LoadingSpinner"
+import { NavigationContainer } from "components/NavigationContainer"
 
 const Header = styled("h1")`
   margin: 30px 50px 30px 40px;
@@ -15,28 +19,80 @@ const Header = styled("h1")`
     margin: 30px 50px 0 20px;
   }
 `
+
+const LoadingContainer = styled("div")`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 300px;
+`
+
 export interface EtusivuProps extends RouteComponentProps {
+  uuid?: string
   store?: IRootStore
+}
+
+interface ShareState {
+  allLoaded: boolean
 }
 
 @inject("store")
 @observer
-export class Etusivu extends React.Component<EtusivuProps> {
-  render = () => (
-    <Container>
-      <Header>
-        <FormattedMessage
-          id="etusivu.tyopaikantoimijantitle"
-          defaultMessage="Työpaikantoimijan etusivu"
-        />
-      </Header>
+export class Etusivu extends React.Component<EtusivuProps, ShareState> {
+  state: ShareState = {
+    allLoaded: false
+  }
 
-      <ContentContainer>
-        <FormattedMessage
-          id="etusivu.tyopaikantoimijansivu"
-          defaultMessage="Työpaikan toimijan ui:n placeholder"
-        />
-      </ContentContainer>
-    </Container>
-  )
+  async componentDidMount() {
+    const { store, uuid } = this.props
+    const { share } = store!
+
+    if (uuid) {
+      await share.fetchShareData(uuid)
+    }
+    if (!share.isLoading) {
+      this.setState({ allLoaded: true })
+    }
+  }
+
+  render() {
+    const { share } = this.props.store!
+    if (!this.state.allLoaded) {
+      return (
+        <LoadingContainer>
+          <LoadingSpinner />
+        </LoadingContainer>
+      )
+    }
+
+    return (
+      <React.Fragment>
+        <NavigationContainer>
+          <Container>
+            <PaddedContent>
+              <MainHeading>
+                <FormattedMessage
+                  id="etusivu.tyopaikantoimijantitle"
+                  defaultMessage="Ammatillisten opintojen henkilökohtaistaminen"
+                />
+              </MainHeading>
+            </PaddedContent>
+          </Container>
+        </NavigationContainer>
+        <Container>
+          <Header>
+            <FormattedMessage
+              id="etusivu.tyopaikantoimijantitle"
+              defaultMessage="Työpaikalla oppija"
+            />
+          </Header>
+        </Container>
+        <Container>
+          <ContentContainer>
+            <ShareLinkInfo share={share.shareData} />
+          </ContentContainer>
+        </Container>
+      </React.Fragment>
+    )
+  }
 }

--- a/tyopaikantoimija/src/stores/EnvironmentStore.ts
+++ b/tyopaikantoimija/src/stores/EnvironmentStore.ts
@@ -21,7 +21,7 @@ const EnvironmentStoreModel = {
 export const EnvironmentStore = types
   .model("EnvironmentStore", EnvironmentStoreModel)
   .actions(self => {
-    const { apiUrl, fetchSingle, fetch, errors, callerId } = getEnv<
+    const { apiUrl, fetchSingle, fetch, errors, appendCallerId } = getEnv<
       StoreEnvironment
     >(self)
 
@@ -30,7 +30,7 @@ export const EnvironmentStore = types
       try {
         const response: APIResponse = yield fetchSingle(
           apiUrl("misc/environment"),
-          { headers: callerId() }
+          { headers: appendCallerId() }
         )
         const {
           eperusteetPerusteUrl,

--- a/tyopaikantoimija/src/stores/RootStore.ts
+++ b/tyopaikantoimija/src/stores/RootStore.ts
@@ -3,6 +3,7 @@ import { EnvironmentStore } from "stores/EnvironmentStore"
 import { IErrorStore } from "stores/ErrorStore"
 import { SessionStore } from "stores/SessionStore"
 import { TranslationStore } from "stores/TranslationStore"
+import { ShareStore } from "stores/ShareStore"
 
 export interface InjectedStores {
   store: IRootStore
@@ -12,7 +13,8 @@ const RootStoreModel = {
   environment: types.optional(EnvironmentStore, {}),
   isLoading: false,
   session: types.optional(SessionStore, {}),
-  translations: types.optional(TranslationStore, {})
+  translations: types.optional(TranslationStore, {}),
+  share: types.optional(ShareStore, {})
 }
 
 export const RootStore = types

--- a/tyopaikantoimija/src/stores/SessionStore.ts
+++ b/tyopaikantoimija/src/stores/SessionStore.ts
@@ -16,16 +16,20 @@ const SessionStoreModel = {
 export const SessionStore = types
   .model("SessionStore", SessionStoreModel)
   .actions(self => {
-    const { apiUrl, fetchSingle, deleteResource, errors, callerId } = getEnv<
-      StoreEnvironment
-    >(self)
+    const {
+      apiUrl,
+      fetchSingle,
+      deleteResource,
+      errors,
+      appendCallerId
+    } = getEnv<StoreEnvironment>(self)
 
     const checkSession = flow(function*(): any {
       self.isLoading = true
       try {
         const response: APIResponse = yield fetchSingle(
           apiUrl("oppija/session"),
-          { headers: callerId() }
+          { headers: appendCallerId() }
         )
         self.user = response.data
       } catch (error) {
@@ -38,7 +42,7 @@ export const SessionStore = types
         try {
           yield fetchSingle(apiUrl("oppija/session/update-user-info"), {
             method: "POST",
-            headers: callerId()
+            headers: appendCallerId()
           })
           yield fetchUserInfo()
         } catch (error) {
@@ -52,7 +56,7 @@ export const SessionStore = types
       try {
         const response: APIResponse = yield fetchSingle(
           apiUrl("oppija/session/user-info"),
-          { headers: callerId() }
+          { headers: appendCallerId() }
         )
         self.user = response.data
       } catch (error) {
@@ -64,7 +68,7 @@ export const SessionStore = types
       try {
         const response: APIResponse = yield fetchSingle(
           apiUrl("oppija/session/settings"),
-          { headers: callerId() }
+          { headers: appendCallerId() }
         )
         self.settings = response.data
       } catch (error) {
@@ -77,7 +81,9 @@ export const SessionStore = types
         yield fetchSingle(apiUrl("oppija/session/settings"), {
           method: "put",
           body: JSON.stringify(getSnapshot(self.settings)),
-          headers: callerId(new Headers({ "Content-Type": "application/json" }))
+          headers: appendCallerId(
+            new Headers({ "Content-Type": "application/json" })
+          )
         })
       } catch (error) {
         errors.logError("SessionStore.saveSettings", error.message)
@@ -87,7 +93,9 @@ export const SessionStore = types
     const logout = flow(function*() {
       self.isLoading = true
       try {
-        yield deleteResource(apiUrl("oppija/session"), { headers: callerId() })
+        yield deleteResource(apiUrl("oppija/session"), {
+          headers: appendCallerId()
+        })
         self.user = undefined
         self.userDidLogout = true
         self.isLoading = false

--- a/tyopaikantoimija/src/stores/ShareStore.ts
+++ b/tyopaikantoimija/src/stores/ShareStore.ts
@@ -36,7 +36,7 @@ export const ShareStoreModel = {
 export const ShareStore = types
   .model("ShareStore", ShareStoreModel)
   .actions(self => {
-    const { apiUrl, apiPrefix, fetchSingle, errors, callerId } = getEnv<
+    const { apiUrl, apiPrefix, fetchSingle, errors, appendCallerId } = getEnv<
       StoreEnvironment
     >(self)
 
@@ -45,7 +45,7 @@ export const ShareStore = types
       try {
         const response: APIResponse = yield fetchSingle(
           apiUrl(`${apiPrefix}/jaot/jakolinkit/${shareUuid}`),
-          { headers: callerId(), credentials: "include" }
+          { headers: appendCallerId(), credentials: "include" }
         )
         self.shareData = response.data
       } catch (error) {

--- a/tyopaikantoimija/src/stores/ShareStore.ts
+++ b/tyopaikantoimija/src/stores/ShareStore.ts
@@ -1,0 +1,65 @@
+import { flow, getEnv, types, Instance } from "mobx-state-tree"
+import { APIResponse } from "types/APIResponse"
+import { StoreEnvironment } from "types/StoreEnvironment"
+import { OsaamisenOsoittaminen } from "models/OsaamisenOsoittaminen"
+import { OsaamisenHankkimistapa } from "models/OsaamisenHankkimistapa"
+
+const tutkintoNimi = types.model("tutkintoNimi", {
+  fi: types.optional(types.string, ""),
+  sv: types.optional(types.string, "")
+})
+
+const tutkinnonosa = types.model("tutkinnonosa", {
+  koulutuksenJarjestajaOid: types.optional(types.string, ""),
+  moduleId: types.optional(types.string, ""),
+  olennainenSeikka: types.optional(types.boolean, false),
+  tutkinnonOsaKoodiUri: types.optional(types.string, ""),
+  tutkinnonOsaKoodiVersio: types.optional(types.number, 1)
+})
+
+export const Share = types.model("Share", {
+  oppijaNimi: types.optional(types.string, ""),
+  oppijaOid: types.optional(types.string, ""),
+  tutkintoNimi: types.optional(tutkintoNimi, {}),
+  voimassaoloAlku: types.optional(types.string, ""),
+  voimassaoloLoppu: types.optional(types.string, ""),
+  osaamisenOsoittaminen: types.maybeNull(OsaamisenOsoittaminen),
+  osaamisenHankkimistapa: types.maybeNull(OsaamisenHankkimistapa),
+  tutkinnonosa: types.maybe(tutkinnonosa)
+})
+
+export const ShareStoreModel = {
+  shareData: types.optional(Share, {}),
+  isLoading: types.optional(types.boolean, false)
+}
+
+export const ShareStore = types
+  .model("ShareStore", ShareStoreModel)
+  .actions(self => {
+    const { apiUrl, apiPrefix, fetchSingle, errors, callerId } = getEnv<
+      StoreEnvironment
+    >(self)
+
+    const fetchShareData = flow(function*(shareUuid: string): any {
+      self.isLoading = true
+      try {
+        const response: APIResponse = yield fetchSingle(
+          apiUrl(`${apiPrefix}/jaot/jakolinkit/${shareUuid}`),
+          { headers: callerId(), credentials: "include" }
+        )
+        self.shareData = response.data
+      } catch (error) {
+        errors.logError(
+          "ShareSTore.fetchShareData",
+          `ShareSTore.fetchShareData.${error.message
+            .replace(" ", "")
+            .toLowerCase()}`
+        )
+      }
+      self.isLoading = false
+    })
+
+    return { fetchShareData }
+  })
+
+export type IShareStore = Instance<typeof ShareStore>

--- a/virkailija/src/index.tsx
+++ b/virkailija/src/index.tsx
@@ -1,7 +1,7 @@
 import { AppContext } from "components/AppContext"
 import { apiPrefix, apiUrl } from "config"
 import { createEnvironment } from "createEnvironment"
-import { callerId, fetch } from "fetchUtils"
+import { appendCallerId, fetch } from "fetchUtils"
 import { Provider } from "mobx-react"
 import "promise-polyfill/src/polyfill" // polyfill Promise for IE 11
 import React from "react"
@@ -18,7 +18,7 @@ addLocaleData([...fi, ...sv])
 // pass fetch utils to RootStore using MST's environment context, so we can easily mock it in tests
 const store = RootStore.create(
   {},
-  createEnvironment(fetch, apiUrl, apiPrefix, callerId)
+  createEnvironment(fetch, apiUrl, apiPrefix, appendCallerId)
 )
 
 store.translations.fetchLocales()

--- a/virkailija/src/routes/HOKSLomake/fetchKoodiUris.ts
+++ b/virkailija/src/routes/HOKSLomake/fetchKoodiUris.ts
@@ -1,12 +1,12 @@
 import { koodistoUrls } from "./formConfig"
 import { buildKoodiUris, mapKoodiUri } from "./helpers/helpers"
-import { callerId } from "fetchUtils"
+import { appendCallerId } from "fetchUtils"
 
 export async function fetchKoodiUris() {
   const requests = await Promise.all(
     Object.keys(koodistoUrls).map(async (key: keyof typeof koodistoUrls) => {
       const json = await window
-        .fetch(koodistoUrls[key], { headers: callerId() })
+        .fetch(koodistoUrls[key], { headers: appendCallerId() })
         .then(r => r.json())
       return {
         key,

--- a/virkailija/src/routes/LuoHOKS.tsx
+++ b/virkailija/src/routes/LuoHOKS.tsx
@@ -38,6 +38,7 @@ import { EditHOKSStyles } from "./HOKSLomake/styles"
 import { SuccessMessage } from "./HOKSLomake/SuccessMessage"
 import { TopToolbar } from "./HOKSLomake/TopToolbar"
 import { propertiesByStep, uiSchemaByStep } from "./LuoHOKS/uiSchema"
+import { appendCallerId } from "fetchUtils"
 
 interface LuoHOKSProps extends RouteComponentProps {
   store?: IRootStore
@@ -189,12 +190,12 @@ export class LuoHOKS extends React.Component<LuoHOKSProps, LuoHOKSState> {
       {
         method: "POST",
         credentials: "include",
-        headers: {
-          Accept: "application/json; charset=utf-8",
-          // "Caller-Id": ""
-          "Content-Type": "application/json"
-          // ticket: """
-        },
+        headers: appendCallerId(
+          new Headers({
+            Accept: "application/json; charset=utf-8",
+            "Content-Type": "application/json"
+          })
+        ),
         body: JSON.stringify(trimEmptyValues(fieldProps.formData))
       }
     )

--- a/virkailija/src/routes/MuokkaaHOKS.tsx
+++ b/virkailija/src/routes/MuokkaaHOKS.tsx
@@ -36,6 +36,7 @@ import { EditHOKSStyles } from "./HOKSLomake/styles"
 import { SuccessMessage } from "./HOKSLomake/SuccessMessage"
 import { TopToolbar } from "./HOKSLomake/TopToolbar"
 import { propertiesByStep, uiSchemaByStep } from "./MuokkaaHOKS/uiSchema"
+import { appendCallerId } from "fetchUtils"
 
 const disallowedKeys = ["eid", "manuaalisyotto", "module-id"]
 
@@ -155,10 +156,12 @@ export class MuokkaaHOKS extends React.Component<
       `/ehoks-virkailija-backend/api/v1/virkailija/oppijat/${oppijaOid}/hoksit/${hoksId}`,
       {
         credentials: "include",
-        headers: {
-          Accept: "application/json; charset=utf-8",
-          "Content-Type": "application/json"
-        }
+        headers: appendCallerId(
+          new Headers({
+            Accept: "application/json; charset=utf-8",
+            "Content-Type": "application/json"
+          })
+        )
       }
     )
     const json = await request.json()
@@ -236,10 +239,12 @@ export class MuokkaaHOKS extends React.Component<
       {
         method: "PUT",
         credentials: "include",
-        headers: {
-          Accept: "application/json; charset=utf-8",
-          "Content-Type": "application/json"
-        },
+        headers: appendCallerId(
+          new Headers({
+            Accept: "application/json; charset=utf-8",
+            "Content-Type": "application/json"
+          })
+        ),
         body: JSON.stringify(trimEmptyValues(fieldProps.formData))
       }
     )

--- a/virkailija/src/routes/Yllapito.tsx
+++ b/virkailija/src/routes/Yllapito.tsx
@@ -9,6 +9,7 @@ import React from "react"
 import { FormattedMessage, intlShape } from "react-intl"
 import { IRootStore } from "stores/RootStore"
 import styled from "styled"
+import { appendCallerId } from "fetchUtils"
 
 export const BackgroundContainer = styled("div")`
   background: #f8f8f8;
@@ -124,10 +125,12 @@ export class Yllapito extends React.Component<YllapitoProps> {
       {
         method: "GET",
         credentials: "include",
-        headers: {
-          Accept: "application/json; charset=utf-8",
-          "Content-Type": "application/json"
-        }
+        headers: appendCallerId(
+          new Headers({
+            Accept: "application/json; charset=utf-8",
+            "Content-Type": "application/json"
+          })
+        )
       }
     )
 
@@ -164,10 +167,12 @@ export class Yllapito extends React.Component<YllapitoProps> {
       {
         method: "DELETE",
         credentials: "include",
-        headers: {
-          Accept: "application/json; charset=utf-8",
-          "Content-Type": "application/json"
-        }
+        headers: appendCallerId(
+          new Headers({
+            Accept: "application/json; charset=utf-8",
+            "Content-Type": "application/json"
+          })
+        )
       }
     )
 
@@ -199,10 +204,12 @@ export class Yllapito extends React.Component<YllapitoProps> {
       {
         method: "POST",
         credentials: "include",
-        headers: {
-          Accept: "application/json; charset=utf-8",
-          "Content-Type": "application/json"
-        }
+        headers: appendCallerId(
+          new Headers({
+            Accept: "application/json; charset=utf-8",
+            "Content-Type": "application/json"
+          })
+        )
       }
     )
 
@@ -235,10 +242,12 @@ export class Yllapito extends React.Component<YllapitoProps> {
       {
         method: "GET",
         credentials: "include",
-        headers: {
-          Accept: "application/json; charset=utf-8",
-          "Content-Type": "application/json"
-        }
+        headers: appendCallerId(
+          new Headers({
+            Accept: "application/json; charset=utf-8",
+            "Content-Type": "application/json"
+          })
+        )
       }
     )
     if (request.status === 200) {
@@ -273,10 +282,12 @@ export class Yllapito extends React.Component<YllapitoProps> {
       {
         method: "GET",
         credentials: "include",
-        headers: {
-          Accept: "application/json; charset=utf-8",
-          "Content-Type": "application/json"
-        }
+        headers: appendCallerId(
+          new Headers({
+            Accept: "application/json; charset=utf-8",
+            "Content-Type": "application/json"
+          })
+        )
       }
     )
     if (request.status === 200) {
@@ -312,10 +323,12 @@ export class Yllapito extends React.Component<YllapitoProps> {
       {
         method: "GET",
         credentials: "include",
-        headers: {
-          Accept: "application/json; charset=utf-8",
-          "Content-Type": "application/json"
-        }
+        headers: appendCallerId(
+          new Headers({
+            Accept: "application/json; charset=utf-8",
+            "Content-Type": "application/json"
+          })
+        )
       }
     )
     if (confirmRequest.status === 200) {
@@ -361,10 +374,12 @@ export class Yllapito extends React.Component<YllapitoProps> {
           {
             method: "DELETE",
             credentials: "include",
-            headers: {
-              Accept: "application/json; charset=utf-8",
-              "Content-Type": "application/json"
-            }
+            headers: appendCallerId(
+              new Headers({
+                Accept: "application/json; charset=utf-8",
+                "Content-Type": "application/json"
+              })
+            )
           }
         )
         if (deleteRequest.status === 200) {
@@ -409,10 +424,12 @@ export class Yllapito extends React.Component<YllapitoProps> {
       {
         method: "PUT",
         credentials: "include",
-        headers: {
-          Accept: "application/json; charset=utf-8",
-          "Content-Type": "application/json"
-        },
+        headers: appendCallerId(
+          new Headers({
+            Accept: "application/json; charset=utf-8",
+            "Content-Type": "application/json"
+          })
+        ),
         body: JSON.stringify({
           "opiskeluoikeus-oid": opiskeluoikeusUpdateOid
         })
@@ -448,10 +465,12 @@ export class Yllapito extends React.Component<YllapitoProps> {
       {
         method: "GET",
         credentials: "include",
-        headers: {
-          Accept: "application/json; charset=utf-8",
-          "Content-Type": "application/json"
-        }
+        headers: appendCallerId(
+          new Headers({
+            Accept: "application/json; charset=utf-8",
+            "Content-Type": "application/json"
+          })
+        )
       }
     )
     if (confirmRequest.status === 200) {
@@ -479,10 +498,12 @@ export class Yllapito extends React.Component<YllapitoProps> {
           {
             method: "PUT",
             credentials: "include",
-            headers: {
-              Accept: "application/json; charset=utf-8",
-              "Content-Type": "application/json"
-            },
+            headers: appendCallerId(
+              new Headers({
+                Accept: "application/json; charset=utf-8",
+                "Content-Type": "application/json"
+              })
+            ),
             body: JSON.stringify({
               "koulutustoimija-oid": koulutustoimijaOid
             })
@@ -529,10 +550,12 @@ export class Yllapito extends React.Component<YllapitoProps> {
       {
         method: "PUT",
         credentials: "include",
-        headers: {
-          Accept: "application/json; charset=utf-8",
-          "Content-Type": "application/json"
-        },
+        headers: appendCallerId(
+          new Headers({
+            Accept: "application/json; charset=utf-8",
+            "Content-Type": "application/json"
+          })
+        ),
         body: JSON.stringify({
           "oppija-oid": updateOppijaOid
         })

--- a/virkailija/src/stores/EnvironmentStore.ts
+++ b/virkailija/src/stores/EnvironmentStore.ts
@@ -18,7 +18,7 @@ const EnvironmentStoreModel = {
 export const EnvironmentStore = types
   .model("EnvironmentStore", EnvironmentStoreModel)
   .actions(self => {
-    const { apiUrl, fetchSingle, fetch, errors, callerId } = getEnv<
+    const { apiUrl, fetchSingle, fetch, errors, appendCallerId } = getEnv<
       StoreEnvironment
     >(self)
 
@@ -27,7 +27,7 @@ export const EnvironmentStore = types
       try {
         const response: APIResponse = yield fetchSingle(
           apiUrl("misc/environment"),
-          { headers: callerId() }
+          { headers: appendCallerId() }
         )
         const { virkailijaLoginUrl, raamitUrl } = response.data
         self.virkailijaLoginUrl = devBackendWithoutHost(virkailijaLoginUrl)

--- a/virkailija/src/stores/KoulutuksenJarjestajaStore.ts
+++ b/virkailija/src/stores/KoulutuksenJarjestajaStore.ts
@@ -35,7 +35,7 @@ export const Oppija = types
     henkilotiedot: types.optional(SessionUser, { surname: "" })
   })
   .actions(self => {
-    const { fetchCollection, fetchSingle, apiUrl, callerId } = getEnv<
+    const { fetchCollection, fetchSingle, apiUrl, appendCallerId } = getEnv<
       StoreEnvironment
     >(self)
 
@@ -43,7 +43,7 @@ export const Oppija = types
     const fetchSuunnitelmat = flow(function*(): any {
       const response: APIResponse = yield fetchCollection(
         apiUrl(`virkailija/oppijat/${self.oid}/hoksit`),
-        { headers: callerId() }
+        { headers: appendCallerId() }
       )
 
       // NOTE: This node might get detached (destroyed) if user navigates
@@ -62,7 +62,7 @@ export const Oppija = types
     const fetchHenkilotiedot = flow(function*(): any {
       const response: APIResponse = yield fetchSingle(
         apiUrl(`virkailija/oppijat/${self.oid}`),
-        { headers: callerId() }
+        { headers: appendCallerId() }
       )
       const { oid, nimi } = response.data
       // NOTE: This node might get detached (destroyed) if user navigates
@@ -159,7 +159,9 @@ const Search = types
     }
   }))
   .actions(self => {
-    const { fetchCollection, apiUrl, callerId } = getEnv<StoreEnvironment>(self)
+    const { fetchCollection, apiUrl, appendCallerId } = getEnv<
+      StoreEnvironment
+    >(self)
 
     const fetchOppijat = flow(function*(): any {
       // TODO fix cross reference of stores?
@@ -196,7 +198,7 @@ const Search = types
           ...queryParams,
           ...textQueries
         }),
-        { headers: callerId() }
+        { headers: appendCallerId() }
       )
       self.results.clear()
       self.results = response.data

--- a/virkailija/src/stores/SessionStore.ts
+++ b/virkailija/src/stores/SessionStore.ts
@@ -33,7 +33,7 @@ export const SessionStore = types
       fetchCollection,
       deleteResource,
       errors,
-      callerId
+      appendCallerId
     } = getEnv<StoreEnvironment>(self)
 
     const checkSession = flow(function*(): any {
@@ -44,7 +44,7 @@ export const SessionStore = types
       }
       try {
         const response = yield fetchSingle(apiUrl("virkailija/session"), {
-          headers: callerId()
+          headers: appendCallerId()
         })
 
         self.user = response.data
@@ -62,7 +62,7 @@ export const SessionStore = types
           withQueryString(apiUrl("virkailija/external/organisaatio/find"), {
             ...queryParams
           }),
-          { headers: callerId() }
+          { headers: appendCallerId() }
         )
         self.organisations = organisationsData.data.map((o: IOrganisation) => ({
           nimi: o.nimi,
@@ -83,7 +83,7 @@ export const SessionStore = types
       self.isLoading = true
       try {
         yield deleteResource(apiUrl("virkailija/session"), {
-          headers: callerId()
+          headers: appendCallerId()
         })
         self.user = undefined
         self.isLoading = false

--- a/virkailija/translations.json
+++ b/virkailija/translations.json
@@ -153,6 +153,7 @@
     "opiskelusuunnitelma.osaamisalaTitle": "Osaamisala",
     "opiskelusuunnitelma.osaamispisteLyhenne": "osp",
     "opiskelusuunnitelma.osaamispistettaPostfix": "osaamispistettä",
+    "opiskelusuunnitelma.osaamistavoitteetTitle": "Osaamistavoitteet",
     "opiskelusuunnitelma.piilotaAmmattitaitovaatimuksetAriaLabel": "Piilota ammattitaitovaatimukset ja arviointikriteerit",
     "opiskelusuunnitelma.piilotaKaikkiKriteeritLink": "Piilota arviointikriteerit",
     "opiskelusuunnitelma.piilotaKriteeritLink": "Piilota arviointikriteerit",


### PR DESCRIPTION
Tässä branchissa siis toteutettu a) linkin tietojen haku bäkkäriltä b) linkin
tietojen tunkeminen shareStoreen (sekä se store) c) linkin tietojen näyttämisen
ihan ensimmäinen drafti. 

Testaus
1. Laita oppijan bäkkäri pyörimään (vaatii sen uusimman masterin, johon eh-981 mergetty, koska siinä palautetaan objekti, eikä arrayta)
2. Avaa oppijan frontti, merkkaa feature flagista share trueksi
3. Luo yksi uusi jakolinkki ja saat näin sen linkin uuid:n siihen käliin
4. Laita myös työpaikantoimijan frontti pyörimään (mutta pidä oppijan frontti,
jotta et saa bäkkäriltä 401:stä, kun ei ole vielä kirjautumista) 
5. Navigoi osoitteeseen:
http://localhost:8081/ehoks-tyopaikantoimija-ui/uuid 
(voit myös klikata sitä "kopioi linkki leikepöydälle", mutta localhostilla siihen pitää vaihtaa oikea portti)


![Screenshot 2020-09-09 at 10 48 53](https://user-images.githubusercontent.com/4289418/92573506-8f334080-f28e-11ea-9637-e70751861fce.png)


Vielä todo
- tutkinnonosan tietojen haku (otsikko + opintopisteet) -rikastus eperusteista?
- loput infot komponenttiin, osaamisala pitäisi lisätä (se tulee jo kyllä
bäkkäristä)
- tutkinnon nimen ja osaamisalan kielistys eli jos kirjautuneena suomenkieliseen
käliin, fi-kenttä ja jos ruotsinkieliseen, sv-kenttä
- kirjautuminen suomi.fi kautta 
- yleisesti ulkoasun parantelu (nyt haxattu tutkinnonOsa -komponentista tommonen
näyttö, mutta invisionissahan oli esmes, että se on silleen pienesti auki ja
sitten klikkaa täysin auki?)