### PR TITLE
EH-748: Title fix

### DIFF
--- a/oppija/translations.json
+++ b/oppija/translations.json
@@ -193,6 +193,7 @@
     "opiskelusuunnitelma.osaamisalaTitle": "Osaamisala",
     "opiskelusuunnitelma.osaamispisteLyhenne": "osp",
     "opiskelusuunnitelma.osaamispistettaPostfix": "osaamispistettä",
+    "opiskelusuunnitelma.osaamistavoitteetTitle": "Osaamistavoitteet",
     "opiskelusuunnitelma.piilotaAmmattitaitovaatimuksetAriaLabel": "Piilota ammattitaitovaatimukset ja arviointikriteerit",
     "opiskelusuunnitelma.piilotaKaikkiKriteeritLink": "Piilota arviointikriteerit",
     "opiskelusuunnitelma.piilotaKriteeritLink": "Piilota arviointikriteerit",

--- a/shared/components/TutkinnonOsa/Competences.tsx
+++ b/shared/components/TutkinnonOsa/Competences.tsx
@@ -136,10 +136,18 @@ export class Competences extends React.Component<CompetencesProps> {
             <CollapseContainer data-testid="TutkinnonOsa.Competences.CollapseContainer">
               <CollapseHeaderContainer>
                 <CollapseHeader>
-                  <FormattedMessage
-                    id="opiskelusuunnitelma.ammattitaitovaatimuksetTitle"
-                    defaultMessage="Ammattitaitovaatimukset"
-                  />
+                  {tutkinnonOsaTyyppi ===
+                  TutkinnonOsaType.HankittavanYhteisenTutkinnonOsanOsaAlue ? (
+                    <FormattedMessage
+                      id="opiskelusuunnitelma.osaamistavoitteetTitle"
+                      defaultMessage="Osaamistavoitteet"
+                    />
+                  ) : (
+                    <FormattedMessage
+                      id="opiskelusuunnitelma.ammattitaitovaatimuksetTitle"
+                      defaultMessage="Ammattitaitovaatimukset"
+                    />
+                  )}
                 </CollapseHeader>
                 <ToggleAllTitle onClick={allExpanded ? collapseAll : expandAll}>
                   {allExpanded ? (

--- a/virkailija/translations.json
+++ b/virkailija/translations.json
@@ -153,6 +153,7 @@
     "opiskelusuunnitelma.osaamisalaTitle": "Osaamisala",
     "opiskelusuunnitelma.osaamispisteLyhenne": "osp",
     "opiskelusuunnitelma.osaamispistettaPostfix": "osaamispistettä",
+    "opiskelusuunnitelma.osaamistavoitteetTitle": "Osaamistavoitteet",
     "opiskelusuunnitelma.piilotaAmmattitaitovaatimuksetAriaLabel": "Piilota ammattitaitovaatimukset ja arviointikriteerit",
     "opiskelusuunnitelma.piilotaKaikkiKriteeritLink": "Piilota arviointikriteerit",
     "opiskelusuunnitelma.piilotaKriteeritLink": "Piilota arviointikriteerit",


### PR DESCRIPTION
Korjattu hyton osa-alueiden osaamistavoitteiden otsikko kun osaamistavoitteet on laajennettu. Aiemmin luki Ammattitaitovaatimukset, nyt Osaamistavoitteet.