### PR TITLE
Eh 1074 telma fix

### DIFF
--- a/shared/models/EPerusteetVastaus.ts
+++ b/shared/models/EPerusteetVastaus.ts
@@ -28,7 +28,7 @@ const ArvioinninKohdealue = types.model({
 
 export const EPerusteetArviointi = types.model({
   id: types.optional(types.number, 0),
-  arvioinninKohdealueet: types.array(ArvioinninKohdealue)
+  arvioinninKohdealueet: types.maybeNull(types.array(ArvioinninKohdealue))
 })
 
 const EPerusteetAmmattitaitovaatimukset = types.model({

--- a/shared/models/YhteinenTutkinnonOsa/OsaAlueVastaus.ts
+++ b/shared/models/YhteinenTutkinnonOsa/OsaAlueVastaus.ts
@@ -5,7 +5,7 @@ import { EPerusteetArviointi, EPerusteetNimi } from "../EPerusteetVastaus"
 const OsaamisTavoitteet = types.model({
   laajuus: types.optional(types.number, 0),
   pakollinen: types.maybe(types.boolean),
-  arviointi: types.optional(EPerusteetArviointi, {})
+  arviointi: types.maybeNull(EPerusteetArviointi)
 })
 
 export const OsaAlueVastaus = types

--- a/shared/models/helpers/getOsaamisvaatimukset.ts
+++ b/shared/models/helpers/getOsaamisvaatimukset.ts
@@ -3,17 +3,19 @@ import { Locale } from "../../stores/TranslationStore"
 
 export function getOsaamisvaatimukset(
   arviointi: {
-    arvioinninKohdealueet: {
-      otsikko: { fi: string; sv: string }
-      arvioinninKohteet: {
-        otsikko: { fi: string; sv: string } | null
-        arviointiAsteikko: string
-        osaamistasonKriteerit: {
-          osaamistaso: string
-          kriteerit: { fi: string; sv: string }[]
+    arvioinninKohdealueet:
+      | {
+          otsikko: { fi: string; sv: string }
+          arvioinninKohteet: {
+            otsikko?: { fi: string; sv: string } | null
+            arviointiAsteikko: string
+            osaamistasonKriteerit: {
+              osaamistaso: string
+              kriteerit: { fi: string; sv: string }[]
+            }[]
+          }[]
         }[]
-      }[]
-    }[]
+      | null
   } | null,
   activeLocale: Locale.FI | Locale.SV
 ) {

--- a/shared/models/helpers/getOsaamisvaatimukset.ts
+++ b/shared/models/helpers/getOsaamisvaatimukset.ts
@@ -17,7 +17,7 @@ export function getOsaamisvaatimukset(
   } | null,
   activeLocale: Locale.FI | Locale.SV
 ) {
-  if (!arviointi) {
+  if (!arviointi || !arviointi.arvioinninKohdealueet) {
     return []
   }
   return arviointi.arvioinninKohdealueet.map(kohdeAlue => ({


### PR DESCRIPTION
Arvionninkohdealueet voi olla null eperusteista tulevassa vastauksessa. Näin on esimerkiksi TELMA-koulutuksen tapauksessa.