### PR TITLE
EH-1099: Laajuus can be null from eperusteet

### DIFF
--- a/shared/models/YhteinenTutkinnonOsa/OsaAlueVastaus.ts
+++ b/shared/models/YhteinenTutkinnonOsa/OsaAlueVastaus.ts
@@ -3,7 +3,7 @@ import { LocaleRoot } from "../helpers/LocaleRoot"
 import { EPerusteetArviointi, EPerusteetNimi } from "../EPerusteetVastaus"
 
 const OsaamisTavoitteet = types.model({
-  laajuus: types.optional(types.number, 0),
+  laajuus: types.optional(types.number, 0, [null, undefined]),
   pakollinen: types.maybe(types.boolean),
   arviointi: types.maybeNull(EPerusteetArviointi)
 })


### PR DESCRIPTION
Osa-alueen laajuus voi olla null eperusteiden vastauksessa.