### PR TITLE
Oy 2728 ja oy 2818

### DIFF
--- a/shared/localeUtils.ts
+++ b/shared/localeUtils.ts
@@ -61,7 +61,18 @@ export function readLocaleFromDomain() {
 
 export function getActiveDomain() {
   const uri = window.location.toString()
-  return uri.includes("studieinfo") ? "studieinfo.fi" : "opintopolku.fi"
+  let prefix = ""
+  if (uri.includes("hahtuva")) {
+    prefix = "hahtuva"
+  } else if (uri.includes("untuva")) {
+    prefix = "untuva"
+  } else if (uri.includes("testi")) {
+    prefix = "testi"
+  }
+  const postfix = uri.includes("studieinfo")
+    ? "studieinfo.fi"
+    : "opintopolku.fi"
+  return prefix + postfix
 }
 
 export function setDocumentLocale(locale: Locale | string) {

--- a/virkailija/src/routes/HOKSLomake/BottomToolbar.tsx
+++ b/virkailija/src/routes/HOKSLomake/BottomToolbar.tsx
@@ -1,7 +1,7 @@
 import styled from "styled"
 
 export const BottomToolbar = styled("div")`
-  position: fixed;
+  position: inherit;
   left: 0px;
   bottom: 0px;
   height: 60px;


### PR DESCRIPTION
Raamien linkit johtamaan siihen ympäristöön jossa ehoks sijaitsee. Chromelle suunnattu korjaus syöttökentän peittävään alapalkin nappulaan (firefoxilla toimi jo aiemmin oikein).