### PR TITLE
OY 3092

### DIFF
--- a/virkailija/src/routes/MuokkaaHOKS.tsx
+++ b/virkailija/src/routes/MuokkaaHOKS.tsx
@@ -38,7 +38,7 @@ import { TopToolbar } from "./HOKSLomake/TopToolbar"
 import { propertiesByStep, uiSchemaByStep } from "./MuokkaaHOKS/uiSchema"
 import { appendCommonHeaders } from "fetchUtils"
 
-const disallowedKeys = ["eid", "manuaalisyotto"]
+const disallowedKeys = ["eid", "manuaalisyotto", "module-id"]
 
 function trimDisallowedKeysForPUTSchema(formData: any) {
   if (typeof formData !== "object") {
@@ -72,9 +72,11 @@ const trimArray = (key: string, formData: any) =>
   formData[key].map((element: any) => trimDisallowedKeysForPUTSchema(element))
 
 function trimPrimitive(key: string, result: any, formData: any) {
-  if (disallowedKeys.includes(key)) {
-    return
-  } else {
+  if (
+    !disallowedKeys.includes(key) ||
+    (Object.keys(formData).includes("osaamisen-hankkimistapa-koodi-uri") &&
+      key === "module-id")
+  ) {
     result[key] = formData[key]
   }
 }

--- a/virkailija/src/routes/MuokkaaHOKS.tsx
+++ b/virkailija/src/routes/MuokkaaHOKS.tsx
@@ -38,7 +38,7 @@ import { TopToolbar } from "./HOKSLomake/TopToolbar"
 import { propertiesByStep, uiSchemaByStep } from "./MuokkaaHOKS/uiSchema"
 import { appendCommonHeaders } from "fetchUtils"
 
-const disallowedKeys = ["eid", "manuaalisyotto", "module-id"]
+const disallowedKeys = ["eid", "manuaalisyotto"]
 
 function trimDisallowedKeysForPUTSchema(formData: any) {
   if (typeof formData !== "object") {


### PR DESCRIPTION
Kenttää module-id ei enää poisteta osaamisen hankkimistapa -objektista, kun se muokataan frontendissa. Näin muokattu osaamisen hankkimistapa korvaa sen vanhan version, eikä uutta luoda. 