### PR TITLE
Epäonnistumisen värin pitää olla punainen ylläpitosivulla

### DIFF
--- a/virkailija/src/routes/Yllapito.tsx
+++ b/virkailija/src/routes/Yllapito.tsx
@@ -146,11 +146,13 @@ export class Yllapito extends React.Component<YllapitoProps> {
     if (request.status === 200) {
       const json: SystemInfoResponse = await request.json()
       this.setState({
+        success: true,
         loadingState: "success",
         systemInfo: json.data
       })
     } else {
       this.setState({
+        success: false,
         loadingState: "unsuccessful",
         message: intl.formatMessage({
           id: "yllapito.jarjestelmanTietojenLatausEpaonnistui",
@@ -187,7 +189,8 @@ export class Yllapito extends React.Component<YllapitoProps> {
 
     if (request.status === 200) {
       this.setState({
-        loadingState: "successfull",
+        success: true,
+        loadingState: "success",
         message: intl.formatMessage({
           id: "yllapito.valimuistiTyhjennetty",
           defaultMessage: "Välimuisti tyhjennetty"
@@ -196,6 +199,7 @@ export class Yllapito extends React.Component<YllapitoProps> {
       await this.loadSystemInfo()
     } else {
       this.setState({
+        success: false,
         loadingState: "unsuccessful",
         message: intl.formatMessage({
           id: "yllapito.valimuistinTyhjennysEpaonnistui",
@@ -372,7 +376,8 @@ export class Yllapito extends React.Component<YllapitoProps> {
 
     if (request.status === 200) {
       this.setState({
-        loadingState: "successfull",
+        success: true,
+        loadingState: "success",
         message: intl.formatMessage({
           id: "yllapito.indeksointiSuoritettu",
           defaultMessage: "Indeksointi suoritettu"
@@ -381,6 +386,7 @@ export class Yllapito extends React.Component<YllapitoProps> {
       await this.loadSystemInfo()
     } else {
       this.setState({
+        success: false,
         loadingState: "unsuccessful",
         message: intl.formatMessage({
           id: "yllapito.indeksointiEpaonnistui",
@@ -411,6 +417,7 @@ export class Yllapito extends React.Component<YllapitoProps> {
       const json = await request.json()
       this.setState({
         success: true,
+        loadingState: "success",
         message: intl.formatMessage({
           id: "yllapito.hoksinHakuOnnistui",
           defaultMessage: "Hoksin haku onnistui"
@@ -421,6 +428,7 @@ export class Yllapito extends React.Component<YllapitoProps> {
     } else {
       this.setState({
         success: false,
+        loadingState: "unsuccessful",
         message: intl.formatMessage({
           id: "yllapito.hoksinHakuEpaonnistui",
           defaultMessage: "Hoksin haku epäonnistui"
@@ -451,6 +459,7 @@ export class Yllapito extends React.Component<YllapitoProps> {
       const json = await request.json()
       this.setState({
         success: true,
+        loadingState: "success",
         message: intl.formatMessage({
           id: "yllapito.opiskeluoikeudenHakuOnnistui",
           defaultMessage: "Opiskeluoikeuden haku onnistui"
@@ -462,6 +471,7 @@ export class Yllapito extends React.Component<YllapitoProps> {
     } else {
       this.setState({
         success: false,
+        loadingState: "unsuccessful",
         message: intl.formatMessage({
           id: "yllapito.opiskeluoikeudenHakuEpaonnistui",
           defaultMessage: "Opiskeluoikeuden haku epäonnistui"
@@ -542,6 +552,7 @@ export class Yllapito extends React.Component<YllapitoProps> {
         if (deleteRequest.status === 200) {
           this.setState({
             success: true,
+            loadingState: "success",
             message: intl.formatMessage({
               id: "yllapito.hoksinPoistoOnnistui",
               defaultMessage: "HOKSin poistaminen onnistui"
@@ -551,6 +562,7 @@ export class Yllapito extends React.Component<YllapitoProps> {
         } else {
           this.setState({
             success: false,
+            loadingState: "unsuccessful",
             message: intl.formatMessage({
               id: "yllapito.hoksinPoistoEpaonnistui",
               defaultMessage: "HOKSin poistaminen epäonnistui"
@@ -562,6 +574,7 @@ export class Yllapito extends React.Component<YllapitoProps> {
     } else {
       this.setState({
         success: false,
+        loadingState: "unsuccessful",
         message: intl.formatMessage({
           id: "yllapito.hoksinVahvistustietojenHakuEpaonnistui",
           defaultMessage:
@@ -592,6 +605,7 @@ export class Yllapito extends React.Component<YllapitoProps> {
     if (palautaRequest.status === 200) {
       this.setState({
         success: true,
+        loadingState: "success",
         message: intl.formatMessage({
           id: "yllapito.hoksinPalautusOnnistui",
           defaultMessage: "HOKSin palautus onnistui"
@@ -601,6 +615,7 @@ export class Yllapito extends React.Component<YllapitoProps> {
     } else {
       this.setState({
         success: false,
+        loadingState: "unsuccessful",
         message: intl.formatMessage({
           id: "yllapito.hoksinPalautusEpaonnistui",
           defaultMessage: "HOKSin palautus epäonnistui"
@@ -633,6 +648,7 @@ export class Yllapito extends React.Component<YllapitoProps> {
     if (request.status === 204) {
       this.setState({
         success: true,
+        loadingState: "success",
         message: intl.formatMessage({
           id: "yllapito.opiskeluoikeudenPaivitysOnnistui",
           defaultMessage: "Opiskeluoikeuden päivitys onnistui"
@@ -642,6 +658,7 @@ export class Yllapito extends React.Component<YllapitoProps> {
     } else {
       this.setState({
         success: false,
+        loadingState: "unsuccessful",
         message: intl.formatMessage({
           id: "yllapito.opiskeluoikeudenPaivitysEpaonnistui",
           defaultMessage: "Opiskeluoikeuden päivitys epäonnistui"
@@ -707,6 +724,7 @@ export class Yllapito extends React.Component<YllapitoProps> {
         if (updateRequest.status === 204) {
           this.setState({
             success: true,
+            loadingState: "success",
             message: intl.formatMessage({
               id: "yllapito.opiskeluoikeuksienPaivitysOnnistui",
               defaultMessage: "Poisto ja uudelleenindeksointi aloitettu"
@@ -716,6 +734,7 @@ export class Yllapito extends React.Component<YllapitoProps> {
         } else {
           this.setState({
             success: false,
+            loadingState: "unsuccessful",
             message: intl.formatMessage({
               id: "yllapito.opiskeluoikeuksienPaivitysEpaonnistui",
               defaultMessage: "Poisto ja uudelleenindeksointi epäonnistui."
@@ -727,6 +746,7 @@ export class Yllapito extends React.Component<YllapitoProps> {
     } else {
       this.setState({
         success: false,
+        loadingState: "unsuccessful",
         message: intl.formatMessage({
           id: "yllapito.opiskeluoikeuksienVahvistustietojenHakuEpaonnistui",
           defaultMessage:
@@ -759,6 +779,7 @@ export class Yllapito extends React.Component<YllapitoProps> {
     if (updateRequest.status === 204) {
       this.setState({
         success: true,
+        loadingState: "success",
         message: intl.formatMessage({
           id: "yllapito.oppijaPaivitetty",
           defaultMessage: "Opiskeluoikeuden päivitys onnistui"
@@ -768,6 +789,7 @@ export class Yllapito extends React.Component<YllapitoProps> {
     } else {
       this.setState({
         success: false,
+        loadingState: "unsuccessful",
         message: intl.formatMessage({
           id: "yllapito.oppijanPaivitysEpaonnistui",
           defaultMessage: "Oppijan päivitys epäonnistui"
@@ -797,6 +819,7 @@ export class Yllapito extends React.Component<YllapitoProps> {
     if (request.status === 204) {
       this.setState({
         success: true,
+        loadingState: "success",
         message: intl.formatMessage({
           id: "yllapito.herateLahetysOnnistui",
           defaultMessage: "Herätteen lähetys onnistui"
@@ -806,6 +829,7 @@ export class Yllapito extends React.Component<YllapitoProps> {
     } else {
       this.setState({
         success: false,
+        loadingState: "unsuccessful",
         message: intl.formatMessage({
           id: "yllapito.herateLahetysEpaonnistui",
           defaultMessage: "Herätteen lähetys epäonnistui"
@@ -835,6 +859,7 @@ export class Yllapito extends React.Component<YllapitoProps> {
     if (request.status === 204) {
       this.setState({
         success: true,
+        loadingState: "success",
         message: intl.formatMessage({
           id: "yllapito.herateLahetysOnnistui",
           defaultMessage: "Herätteen lähetys onnistui"
@@ -844,6 +869,7 @@ export class Yllapito extends React.Component<YllapitoProps> {
     } else {
       this.setState({
         success: false,
+        loadingState: "unsuccessful",
         message: intl.formatMessage({
           id: "yllapito.herateLahetysEpaonnistui",
           defaultMessage: "Herätteen lähetys epäonnistui"
@@ -876,6 +902,7 @@ export class Yllapito extends React.Component<YllapitoProps> {
       const count = json.data.count
       this.setState({
         success: true,
+        loadingState: "success",
         message: intl.formatMessage(
           {
             id: "yllapito.heratteetLahetysOnnistui",
@@ -888,6 +915,7 @@ export class Yllapito extends React.Component<YllapitoProps> {
     } else {
       this.setState({
         success: false,
+        loadingState: "unsuccessful",
         message: intl.formatMessage({
           id: "yllapito.heratteetLahetysEpaonnistui",
           defaultMessage: "Virhe herätteiden uudelleenlähetyksessä!"
@@ -920,6 +948,7 @@ export class Yllapito extends React.Component<YllapitoProps> {
       const count = json.data.count
       this.setState({
         success: true,
+        loadingState: "success",
         message: intl.formatMessage(
           {
             id: "yllapito.heratteetLahetysOnnistui",
@@ -932,6 +961,7 @@ export class Yllapito extends React.Component<YllapitoProps> {
     } else {
       this.setState({
         success: false,
+        loadingState: "unsuccessful",
         message: intl.formatMessage({
           id: "yllapito.heratteetLahetysEpaonnistui",
           defaultMessage: "Virhe herätteiden uudelleenlähetyksessä!"


### PR DESCRIPTION
Ylläpitosivulla "epäonnistunut"-viestit näkyivät vihreinä, vaikka niiden pitäisi olla punaisia. Tämä on korjaus siihen.