### PR TITLE
Add organisation OID to links and URLs in all HOKS viewing components

### DIFF
--- a/virkailija/src/routes/App.tsx
+++ b/virkailija/src/routes/App.tsx
@@ -81,6 +81,8 @@ export class App extends React.Component<AppProps> {
         ? translations
         : // use finnish translations as fallback, merge provided translations
           { ...store!.translations.messages.fi, ...translations }
+    const selectedOrganisationOid = store!.session.selectedOrganisationOid
+    const defaultPath = `/ehoks-virkailija-ui/koulutuksenjarjestaja/${selectedOrganisationOid}`
 
     return (
       <ThemeWrapper>
@@ -95,17 +97,14 @@ export class App extends React.Component<AppProps> {
             <Header />
             <AppNotifications />
             <StyledRouter basepath="/ehoks-virkailija-ui">
-              <Redirect
-                from="/"
-                to="/ehoks-virkailija-ui/koulutuksenjarjestaja"
-                noThrow={true}
-              />
+              <Redirect from="/" to={defaultPath} noThrow={true} />
               <LuoHOKS path="luohoks" />
               <MuokkaaHOKS path="hoks/:oppijaOid/:hoksId" />
-              <KoulutuksenJarjestaja path="koulutuksenjarjestaja" />
+              <Redirect from="/koulutuksenjarjestaja" to={defaultPath} />
+              <KoulutuksenJarjestaja path="koulutuksenjarjestaja/:orgId" />
+              <Opiskelija path="koulutuksenjarjestaja/:orgId/oppija/:studentId/*" />
               <Yllapito path="yllapito" />
               <Raportit path="raportit" />
-              <Opiskelija path="koulutuksenjarjestaja/:studentId/*" />
             </StyledRouter>
             <GlobalStyles />
           </Container>

--- a/virkailija/src/routes/Header.tsx
+++ b/virkailija/src/routes/Header.tsx
@@ -1,4 +1,4 @@
-import { Link } from "@reach/router"
+import { Link, navigate } from "@reach/router"
 import { OrganisationDropdown } from "components/OrganisationDropdown"
 import { inject, observer } from "mobx-react"
 import React from "react"
@@ -68,6 +68,7 @@ export class Header extends React.Component<HeaderProps> {
     koulutuksenJarjestaja.search.resetActivePage()
     koulutuksenJarjestaja.search.fetchOppijat()
     localStorage.setItem("selectedOrganisationOid", oid)
+    navigate(`/ehoks-virkailija-ui/koulutuksenjarjestaja/${oid}`)
   }
 
   render() {

--- a/virkailija/src/routes/KoulutuksenJarjestaja.tsx
+++ b/virkailija/src/routes/KoulutuksenJarjestaja.tsx
@@ -54,6 +54,8 @@ const Spinner = styled(LoadingSpinner)`
 
 interface KoulutuksenJarjestajaProps extends RouteComponentProps {
   store?: IRootStore
+  // from path parameters
+  orgId?: string
 }
 
 @inject("store")
@@ -73,10 +75,14 @@ export class KoulutuksenJarjestaja extends React.Component<
 
   componentDidMount() {
     const { koulutuksenJarjestaja, session } = this.props.store!
+    const orgId = this.props.orgId
 
     this.disposeLoginReaction = reaction(
       () => session.isLoggedIn && session.organisations.length > 0,
       async hasLoggedIn => {
+        if (orgId && orgId !== session.selectedOrganisationOid) {
+          session.changeSelectedOrganisationOid(orgId)
+        }
         if (hasLoggedIn) {
           await koulutuksenJarjestaja.search.fetchOppijat()
           window.requestAnimationFrame(() => {
@@ -134,6 +140,7 @@ export class KoulutuksenJarjestaja extends React.Component<
       isLoading,
       searchTexts
     } = koulutuksenJarjestaja.search
+    const selectedOrganisationOid = this.props.orgId
 
     return (
       <BackgroundContainer>
@@ -215,7 +222,7 @@ export class KoulutuksenJarjestaja extends React.Component<
                       <TableCell>
                         {student.lukumaara > 0 ? (
                           <Link
-                            to={`/ehoks-virkailija-ui/koulutuksenjarjestaja/${student.oid}`}
+                            to={`/ehoks-virkailija-ui/koulutuksenjarjestaja/${selectedOrganisationOid}/oppija/${student.oid}`}
                           >
                             {student.nimi}
                           </Link>

--- a/virkailija/src/routes/KoulutuksenJarjestaja/KoulutuksenJarjestajaHOKS.tsx
+++ b/virkailija/src/routes/KoulutuksenJarjestaja/KoulutuksenJarjestajaHOKS.tsx
@@ -64,6 +64,7 @@ export interface KoulutuksenJarjestajaHOKSProps
   oppija?: IOppija
   /* From router path */
   hoksId?: string
+  laitosId?: string
 }
 
 @inject("store")
@@ -123,7 +124,7 @@ export class KoulutuksenJarjestajaHOKS extends React.Component<
   }
 
   render() {
-    const { hoksId, location, suunnitelmat, oppija } = this.props
+    const { hoksId, location, suunnitelmat, oppija, laitosId } = this.props
     const suunnitelmaHoksId =
       this.props.location &&
       this.props.location.state &&
@@ -134,6 +135,10 @@ export class KoulutuksenJarjestajaHOKS extends React.Component<
     if (!oppija || !suunnitelma) {
       return null
     }
+    const oppijaPath = `/ehoks-virkailija-ui/koulutuksenjarjestaja/${laitosId}/oppija/${oppija.oid}`
+    const hoksPath = `${oppijaPath}/${suunnitelma.eid}`
+    const osaamisPath = `${hoksPath}/osaaminen`
+    const opsPath = `${hoksPath}/opiskelusuunnitelma`
 
     return (
       <React.Fragment>
@@ -142,9 +147,7 @@ export class KoulutuksenJarjestajaHOKS extends React.Component<
             <PaddedContent>
               {suunnitelmat.length > 1 && (
                 <Timestamp>
-                  <StudentLink
-                    to={`/ehoks-virkailija-ui/koulutuksenjarjestaja/${oppija.oid}`}
-                  >
+                  <StudentLink to={oppijaPath}>
                     <FormattedMessage
                       id="koulutuksenJarjestaja.opiskelija.naytaKaikkiLink"
                       defaultMessage="Näytä kaikki tämän opiskelijan suunnitelmat"
@@ -156,13 +159,8 @@ export class KoulutuksenJarjestajaHOKS extends React.Component<
                 <HOKSInfo suunnitelma={suunnitelma} oppija={oppija} />
                 <SectionItems>
                   <SectionItem
-                    selected={
-                      location?.pathname ===
-                      `/ehoks-virkailija-ui/koulutuksenjarjestaja/${oppija.oid}/${suunnitelma.eid}`
-                    }
-                    onClick={this.setActiveTab(
-                      `/ehoks-virkailija-ui/koulutuksenjarjestaja/${oppija.oid}/${suunnitelma.eid}`
-                    )}
+                    selected={location?.pathname === hoksPath}
+                    onClick={this.setActiveTab(hoksPath)}
                     title={
                       <FormattedMessage
                         id="koulutuksenJarjestaja.opiskelija.tavoiteTitle"
@@ -173,13 +171,8 @@ export class KoulutuksenJarjestajaHOKS extends React.Component<
                     <Flag />
                   </SectionItem>
                   <SectionItem
-                    selected={
-                      location?.pathname ===
-                      `/ehoks-virkailija-ui/koulutuksenjarjestaja/${oppija.oid}/${suunnitelma.eid}/osaaminen`
-                    }
-                    onClick={this.setActiveTab(
-                      `/ehoks-virkailija-ui/koulutuksenjarjestaja/${oppija.oid}/${suunnitelma.eid}/osaaminen`
-                    )}
+                    selected={location?.pathname === osaamisPath}
+                    onClick={this.setActiveTab(osaamisPath)}
                     title={
                       <FormattedMessage
                         id="koulutuksenJarjestaja.opiskelija.aiempiOsaaminenTitle"
@@ -190,13 +183,8 @@ export class KoulutuksenJarjestajaHOKS extends React.Component<
                     <MdExtension />
                   </SectionItem>
                   <SectionItem
-                    selected={
-                      location?.pathname ===
-                      `/ehoks-virkailija-ui/koulutuksenjarjestaja/${oppija.oid}/${suunnitelma.eid}/opiskelusuunnitelma`
-                    }
-                    onClick={this.setActiveTab(
-                      `/ehoks-virkailija-ui/koulutuksenjarjestaja/${oppija.oid}/${suunnitelma.eid}/opiskelusuunnitelma`
-                    )}
+                    selected={location?.pathname === opsPath}
+                    onClick={this.setActiveTab(opsPath)}
                     title={
                       <FormattedMessage
                         id="koulutuksenJarjestaja.opiskelija.opiskelusuunnitelmaTitle"
@@ -215,9 +203,7 @@ export class KoulutuksenJarjestajaHOKS extends React.Component<
         <BackgroundContainer>
           <Container>
             <PaddedContent>
-              <Router
-                basepath={`/ehoks-virkailija-ui/koulutuksenjarjestaja/${oppija.oid}/${suunnitelma.eid}`}
-              >
+              <Router basepath={hoksPath}>
                 <Tavoitteet
                   path="/"
                   student={oppija.henkilotiedot}

--- a/virkailija/src/routes/KoulutuksenJarjestaja/Opiskelija.tsx
+++ b/virkailija/src/routes/KoulutuksenJarjestaja/Opiskelija.tsx
@@ -38,7 +38,8 @@ const TopContainer = styled("div")`
 
 export interface OpiskelijaProps {
   store?: IRootStore
-  /* From router path */
+  // From router path
+  orgId?: string
   studentId?: string
 }
 
@@ -57,6 +58,11 @@ export class Opiskelija extends React.Component<
     this.disposeLoginReaction = reaction(
       () => session.isLoggedIn && session.organisations.length > 0,
       async hasLoggedIn => {
+        const orgId = this.props.orgId
+        if (orgId && orgId !== session.selectedOrganisationOid) {
+          session.changeSelectedOrganisationOid(orgId)
+        }
+
         if (hasLoggedIn) {
           if (!search.results.length) {
             await search.fetchOppijat()
@@ -87,7 +93,7 @@ export class Opiskelija extends React.Component<
   }
 
   render() {
-    const { studentId, store } = this.props
+    const { studentId, orgId, store } = this.props
     if (!studentId) {
       return null
     }
@@ -102,6 +108,8 @@ export class Opiskelija extends React.Component<
       results.length && studentIndex !== -1 && studentIndex + 1 < results.length
         ? results[studentIndex + 1]
         : undefined
+    const basePath = `/ehoks-virkailija-ui/koulutuksenjarjestaja/${orgId}/oppija`
+    const selfPath = `${basePath}/${studentId}`
 
     return (
       <React.Fragment>
@@ -109,9 +117,7 @@ export class Opiskelija extends React.Component<
           <TopContainer>
             <LeftLink>
               {previous && (
-                <StudentLink
-                  to={`/ehoks-virkailija-ui/koulutuksenjarjestaja/${previous.oid}`}
-                >
+                <StudentLink to={`${basePath}/${previous.oid}`}>
                   &lt;&lt; {previous.nimi}
                 </StudentLink>
               )}
@@ -126,21 +132,18 @@ export class Opiskelija extends React.Component<
             </LinkContainer>
             <RightLink>
               {next && (
-                <StudentLink
-                  to={`/ehoks-virkailija-ui/koulutuksenjarjestaja/${next.oid}`}
-                >
+                <StudentLink to={`${basePath}/${next.oid}`}>
                   {next.nimi} &gt;&gt;
                 </StudentLink>
               )}
             </RightLink>
           </TopContainer>
         )}
-        <Router
-          basepath={`/ehoks-virkailija-ui/koulutuksenjarjestaja/${studentId}`}
-        >
+        <Router basepath={selfPath}>
           <ValitseHOKS
             path="/"
             oppijaId={studentId}
+            laitosId={orgId || "unknown"}
             nimi={oppija?.nimi}
             suunnitelmat={suunnitelmat}
             session={session}
@@ -149,6 +152,7 @@ export class Opiskelija extends React.Component<
             path=":hoksId/*"
             suunnitelmat={suunnitelmat}
             oppija={oppija}
+            laitosId={orgId || "unknown"}
           />
         </Router>
       </React.Fragment>

--- a/virkailija/src/routes/KoulutuksenJarjestaja/Opiskelija.tsx
+++ b/virkailija/src/routes/KoulutuksenJarjestaja/Opiskelija.tsx
@@ -63,6 +63,10 @@ export class Opiskelija extends React.Component<
           }
 
           if (studentId) {
+            const maybeOppija = search.oppija(studentId)
+            if (!maybeOppija) {
+              await search.fetchOppija(studentId)
+            }
             const oppija = search.oppija(studentId)
             if (oppija) {
               await oppija.fetchOpiskeluoikeudet()

--- a/virkailija/src/routes/KoulutuksenJarjestaja/ValitseHOKS.tsx
+++ b/virkailija/src/routes/KoulutuksenJarjestaja/ValitseHOKS.tsx
@@ -16,6 +16,7 @@ import { Instance } from "mobx-state-tree"
 interface ValitseHOKSProps extends RouteComponentProps {
   nimi?: string
   oppijaId: string
+  laitosId: string
   suunnitelmat: IHOKS[]
   session: ISessionStore
 }
@@ -25,7 +26,7 @@ export class ValitseHOKS extends React.Component<ValitseHOKSProps> {
   static contextType = AppContext
   declare context: React.ContextType<typeof AppContext>
   render() {
-    const { nimi, suunnitelmat, oppijaId, session } = this.props
+    const { nimi, suunnitelmat, oppijaId, laitosId, session } = this.props
     const { app } = this.context
     const [paattyneet, voimassaOlevat] = partition<IHOKS>(
       suunnitelmat,
@@ -37,6 +38,8 @@ export class ValitseHOKS extends React.Component<ValitseHOKSProps> {
       oppijaId !== "" &&
       suunnitelma.manuaalisyotto &&
       session.hasEditPrivilege === true
+
+    const hoksPath = `/ehoks-virkailija-ui/koulutuksenjarjestaja/${laitosId}/oppija/${oppijaId}/`
 
     return (
       <React.Fragment>
@@ -61,7 +64,7 @@ export class ValitseHOKS extends React.Component<ValitseHOKSProps> {
 
                 {voimassaOlevat.map((suunnitelma, i) => (
                   <Suunnitelma
-                    hoksPath={`/ehoks-virkailija-ui/koulutuksenjarjestaja/${oppijaId}/`}
+                    hoksPath={hoksPath}
                     suunnitelma={suunnitelma}
                     oppijaId={oppijaId}
                     showEditIcon={isHoksEditIconVisible(suunnitelma)}
@@ -81,7 +84,7 @@ export class ValitseHOKS extends React.Component<ValitseHOKSProps> {
 
                 {paattyneet.map((suunnitelma, i) => (
                   <Suunnitelma
-                    hoksPath={`/ehoks-virkailija-ui/koulutuksenjarjestaja/${oppijaId}/`}
+                    hoksPath={hoksPath}
                     suunnitelma={suunnitelma}
                     oppijaId={oppijaId}
                     showEditIcon={isHoksEditIconVisible(suunnitelma)}

--- a/virkailija/src/routes/Raportit.tsx
+++ b/virkailija/src/routes/Raportit.tsx
@@ -360,6 +360,9 @@ export class Raportit extends React.Component<RaportitProps> {
     this.state.data?.find((x: TpjRow) => x.hoksId === hoksId) as TpjRow
 
   createLinkPath = (hoksId: number) => {
+    const { store } = this.props
+    const oppilaitosOid: string | undefined =
+      store?.session.selectedOrganisationOid
     let row = {} as HoksRow | TpjRow
     let oppijaOid = ""
     let hoksEid = ""
@@ -376,7 +379,7 @@ export class Raportit extends React.Component<RaportitProps> {
         break
     }
     return oppijaOid.length && hoksEid.length
-      ? `/ehoks-virkailija-ui/koulutuksenjarjestaja/${oppijaOid}/${hoksEid}`
+      ? `/ehoks-virkailija-ui/koulutuksenjarjestaja/${oppilaitosOid}/oppija/${oppijaOid}/${hoksEid}`
       : "/ehoks-virkailija-ui/raportit"
   }
 

--- a/virkailija/src/stores/KoulutuksenJarjestajaStore.ts
+++ b/virkailija/src/stores/KoulutuksenJarjestajaStore.ts
@@ -108,12 +108,14 @@ export const Oppija = types
       return self.suunnitelmat.length
     },
     get editLink(): string {
+      const rootStore: IRootStore = getRoot<IRootStore>(self)
+      const oppilaitosOid: string = rootStore.session.selectedOrganisationOid
       const manualPlans = self.suunnitelmat.filter(
         suunnitelma => suunnitelma.manuaalisyotto
       )
       return manualPlans.length
         ? manualPlans.length > 1
-          ? `/ehoks-virkailija-ui/koulutuksenjarjestaja/${self.oid}`
+          ? `/ehoks-virkailija-ui/koulutuksenjarjestaja/${oppilaitosOid}/oppija/${self.oid}`
           : `/ehoks-virkailija-ui/hoks/${self.oid}/${manualPlans[0].id}`
         : ""
     },


### PR DESCRIPTION
Tämänhetkinen tilanne: suorat linkit HOKSiin toimivat vain, jos linkin avaajalla sattuu olemaan (esim. localStoragessa) valittuna organisaatio, jolla on oikeus tarkastella kyseisen oppijan HOKSeja.

Haluttu tilanne: suorat linkit toimivat aina.

Tämä PR muuttaa kaikki virkailijan näkymät oppijaan ja oppijan HOKSeihin sellaisiksi, että URL-osoitteessa on mukana organisaatio, jonka kautta oppija löydettiin.  Kun näihin URLeihin sitten menee uudella selaimella / välilehdellä, virkailijalla aktiivinen (valittu) organisaatio asetetaan URL-osoitteen organisaatioksi, niin että oppija HOKSeineen löydetään jälleen.

PR rakentuu [tämän toisen korjauksen](https://github.com/Opetushallitus/ehoks-ui/pull/444) päälle (ja sisältää sen).