### PR TITLE
TUVA: use koulutuksenOsa viiteId for deep linking to ePerusteet

### DIFF
--- a/shared/components/KoulutuksenOsa.tsx
+++ b/shared/components/KoulutuksenOsa.tsx
@@ -145,6 +145,7 @@ export interface KoulutuksenOsaProps {
   alku?: string
   loppu?: string
   laajuus?: number
+  viiteId?: number
 }
 
 export interface KoulutuksenOsaState {
@@ -213,8 +214,12 @@ export class KoulutuksenOsa extends React.Component<
       width = "25%",
       alku,
       loppu,
-      laajuus
+      laajuus,
+      viiteId
     } = this.props
+    const ePerusteetLinkki = viiteId
+      ? `https://eperusteet.opintopolku.fi/#/fi/tutkintoonvalmentava/7534950/koulutuksenosa/${viiteId}`
+      : "https://eperusteet.opintopolku.fi/#/fi/tutkintoonvalmentava/7534950/linkkisivu/7535290"
 
     return (
       <Container accentColor={accentColor} width={width}>
@@ -247,11 +252,7 @@ export class KoulutuksenOsa extends React.Component<
               </Detail>
               <Detail>
                 {" "}
-                <a
-                  href="https://eperusteet.opintopolku.fi/#/fi/tutkintoonvalmentava/7534950/linkkisivu/7535290"
-                  target="_blank"
-                  rel="noreferrer"
-                >
+                <a href={ePerusteetLinkki} target="_blank" rel="noreferrer">
                   <FormattedMessage
                     id="opiskelusuunnitelma.ePerusteLinkki"
                     defaultMessage="Linkki ePerusteisiin"

--- a/shared/components/Opiskelija/StudyPlan/CompletedStudies.tsx
+++ b/shared/components/Opiskelija/StudyPlan/CompletedStudies.tsx
@@ -106,6 +106,7 @@ export class CompletedStudies extends React.Component<CompletedStudiesProps> {
                     alku={study.alku}
                     loppu={study.loppu}
                     laajuus={study.laajuus}
+                    viiteId={study.tutkinnonOsa?.koulutuksenOsaViiteId}
                   />
                   {renderExtraItem && <EmptyItem />}
                 </React.Fragment>

--- a/shared/components/Opiskelija/StudyPlan/ScheduledStudies.tsx
+++ b/shared/components/Opiskelija/StudyPlan/ScheduledStudies.tsx
@@ -105,6 +105,7 @@ export class ScheduledStudies extends React.Component<ScheduledStudiesProps> {
                     alku={study.alku}
                     loppu={study.loppu}
                     laajuus={study.laajuus}
+                    viiteId={study.tutkinnonOsa?.koulutuksenOsaViiteId}
                   />
                   {renderExtraItem && <EmptyItem />}
                 </React.Fragment>

--- a/shared/models/EPerusteetVastaus.ts
+++ b/shared/models/EPerusteetVastaus.ts
@@ -55,5 +55,5 @@ export const EPerusteetVastaus = types.model("EPerusteet", {
     EPerusteetAmmattitaidonOsoittamistavat
   ),
   nimi: types.optional(EPerusteetNimi, {}),
-  koulutuksenOsaId: types.optional(types.string, "")
+  koulutuksenOsaViiteId: types.optional(types.number, 0)
 })


### PR DESCRIPTION
this PR needs https://github.com/Opetushallitus/ehoks/pull/524 to work.