### PR TITLE
Hide yksiloiva tunniste from HOKS UI

### DIFF
--- a/virkailija/src/routes/LuoHOKS/uiSchema.ts
+++ b/virkailija/src/routes/LuoHOKS/uiSchema.ts
@@ -569,6 +569,9 @@ const fullUiSchema = (options: UiSchemaOptions): { [key: string]: any } => ({
           id: {
             "ui:widget": "hidden"
           },
+          "yksiloiva-tunniste": {
+            "ui:widget": "hidden"
+          },
           "osaamisen-hankkimistapa-koodi-uri": {
             "ui:field": "typeahead",
             typeahead: typeaheadProps(options.osaamisenhankkimistapa)
@@ -755,6 +758,9 @@ const fullUiSchema = (options: UiSchemaOptions): { [key: string]: any } => ({
             "*"
           ],
           id: {
+            "ui:widget": "hidden"
+          },
+          "yksiloiva-tunniste": {
             "ui:widget": "hidden"
           },
           "osaamisen-hankkimistapa-koodi-uri": {
@@ -965,6 +971,9 @@ const fullUiSchema = (options: UiSchemaOptions): { [key: string]: any } => ({
                 "*"
               ],
               id: {
+                "ui:widget": "hidden"
+              },
+              "yksiloiva-tunniste": {
                 "ui:widget": "hidden"
               },
               "osaamisen-hankkimistapa-koodi-uri": {

--- a/virkailija/src/routes/MuokkaaHOKS/uiSchema.ts
+++ b/virkailija/src/routes/MuokkaaHOKS/uiSchema.ts
@@ -589,6 +589,9 @@ const fullUiSchema = (options: UiSchemaOptions): { [key: string]: any } => ({
           id: {
             "ui:widget": "hidden"
           },
+          "yksiloiva-tunniste": {
+            "ui:widget": "hidden"
+          },
           "module-id": {
             "ui:widget": "hidden"
           },
@@ -784,6 +787,9 @@ const fullUiSchema = (options: UiSchemaOptions): { [key: string]: any } => ({
             "*"
           ],
           id: {
+            "ui:widget": "hidden"
+          },
+          "yksiloiva-tunniste": {
             "ui:widget": "hidden"
           },
           "module-id": {
@@ -1006,6 +1012,9 @@ const fullUiSchema = (options: UiSchemaOptions): { [key: string]: any } => ({
                 "*"
               ],
               id: {
+                "ui:widget": "hidden"
+              },
+              "yksiloiva-tunniste": {
                 "ui:widget": "hidden"
               },
               "module-id": {


### PR DESCRIPTION
## Kuvaus muutoksista

Kuten weeklyssa sovittiin, piilotetaan yksilöivä tunniste käyttöliittymässä.  Todennäköisesti se on vain unohtunut aikanaan tehdä; ihmisillä ei voi olla hyötyä sen syöttämisestä käsin, eikä varsinkaan muokkaamisesta.

https://jira.eduuni.fi/browse/EH-1472

## Muistilista PR:n tekijälle ja katselmoijille

### Ennen asettamista katselmointiin
  - [x] Build onnistuu ilman virheitä
  - [ ] Toiminnallisuuden kattavat yksikkötestit on tehty osana PR:ia
  - [x] PR:n sisältämät muutokset noudattavat [sovittuja koodikäytänteitä](../doc/code-guidelines.md)
  - [x] Koodi on riittävästi dokumentoitu tai se on muuten yksiselitteistä
  - [x] Nimet (muuttujat, funktiot, ...) kuvaavat koodia hyvin

❗ **Katselmoijat tarkastavat, että yllä mainitut kohdat toteutuvat**

### Ennen mergeämistä `master`-haaralle
  - [x] Vähintään yksi kehittäjä on katselmoinut ja hyväksynyt muutokset
    - Jos muutoksilla voi jotain rikkoessaan olla kauaskantoiset vaikutukset, kannattaa muutokset hyväksyttää useammalla katselmoijalla
  - [x] Katselmoijien esittämät muutosehdotukset on huomioitu
  - [x] Muutokset on testattu QA-ympäristössä
  - [x] Yli jääneet kehityskohteet on tiketöity
