### PR TITLE
OY-4449: korjataan useat virhetilanteet tutkinnonosien tietojen haussa ePerusteista

### DIFF
--- a/oppija/translations.json
+++ b/oppija/translations.json
@@ -33,7 +33,7 @@
     "errors.NotificationStore.haeOpiskelijapalautelinkit": "Opiskelijapalautelinkkien haku epäonnistui",
     "errors.Opiskelijapalaute.resendPalaute": "Virhe uudelleenlähetyspyynnön käsittelyssä",
     "errors.OppilasStore.haePerusteet": "Ammatillisten tutkintojen haku epäonnistui",
-    "errors.OsaAlueVastaus.nimeaEiLoytynyt": "Osa-alueen nimen lataaminen ei onnistunut. Tämä on tilapäinen häiriö.",
+    "errors.OsaAlueVastaus.nimeaEiLoytynyt": "tietojen lataaminen ePerusteet-palvelusta ei onnistunut.",
     "errors.piilotaVirheAriaLabel": "Piilota virhe",
     "errors.SessionStore.checkSession": "Kirjautumistietojen tarkastus epäonnistui",
     "errors.SessionStore.getUserInfo": "Käyttäjätietojen haku epäonnistui",

--- a/shared/models/AiemminHankittuAmmatillinenTutkinnonOsa.ts
+++ b/shared/models/AiemminHankittuAmmatillinenTutkinnonOsa.ts
@@ -45,7 +45,12 @@ export const AiemminHankittuAmmatillinenTutkinnonOsa = types
     const root: LocaleRoot = getRoot(self)
     return {
       get otsikko(): JSX.Element | string {
-        return self.tutkinnonOsa.nimi[root.translations.activeLocale]
+        return (
+          self.tutkinnonOsa.nimi[root.translations.activeLocale] ||
+          self.tutkinnonOsa.koodi.nimi[root.translations.activeLocale] ||
+          self.tutkinnonOsa.nimi.fi ||
+          self.tutkinnonOsa.koodi.nimi.fi
+        )
       },
       get osaamispisteet() {
         return getOsaamispisteet(self.tutkinnonOsaViitteet)

--- a/shared/models/AiemminHankittuAmmatillinenTutkinnonOsa.ts
+++ b/shared/models/AiemminHankittuAmmatillinenTutkinnonOsa.ts
@@ -45,9 +45,7 @@ export const AiemminHankittuAmmatillinenTutkinnonOsa = types
     const root: LocaleRoot = getRoot(self)
     return {
       get otsikko(): JSX.Element | string {
-        return self.tutkinnonOsa && self.tutkinnonOsa.nimi
-          ? self.tutkinnonOsa.nimi[root.translations.activeLocale]
-          : ""
+        return self.tutkinnonOsa.nimi[root.translations.activeLocale]
       },
       get osaamispisteet() {
         return getOsaamispisteet(self.tutkinnonOsaViitteet)

--- a/shared/models/EPerusteetVastaus.ts
+++ b/shared/models/EPerusteetVastaus.ts
@@ -59,5 +59,6 @@ export const EPerusteetVastaus = types.model("EPerusteet", {
     EPerusteetAmmattitaidonOsoittamistavat
   ),
   nimi: types.optional(EPerusteetNimi, {}),
+  koodi: types.optional(EPerusteKoodi, {}),
   koulutuksenOsaViiteId: types.optional(types.number, 0)
 })

--- a/shared/models/Enrichment/EnrichTutkinnonOsaKoodiUri.ts
+++ b/shared/models/Enrichment/EnrichTutkinnonOsaKoodiUri.ts
@@ -41,7 +41,13 @@ export const EnrichTutkinnonOsaKoodiUri = types
         cachedResponses[koodiUri] =
           cachedResponses[koodiUri] || getFromEPerusteetService(koodiUri)
         const response: APIResponse = yield cachedResponses[koodiUri]
-        self.tutkinnonOsa = response.data
+        if (Array.isArray(response.data)) {
+          const tutkinnonOsat = [...response.data]
+          tutkinnonOsat.sort((to1, to2) => to2.muokattu - to1.muokattu)
+          self.tutkinnonOsa = tutkinnonOsat[0]
+        } else {
+          self.tutkinnonOsa = response.data
+        }
       } catch (error) {
         errors.logError("EnrichKoodiUri.fetchEPerusteet", error.message)
       }

--- a/shared/models/HankittavaAmmatillinenTutkinnonOsa.ts
+++ b/shared/models/HankittavaAmmatillinenTutkinnonOsa.ts
@@ -42,9 +42,7 @@ export const HankittavaAmmatillinenTutkinnonOsa = types
     const root: LocaleRoot = getRoot(self)
     return {
       get otsikko(): JSX.Element | string {
-        return self.tutkinnonOsa && self.tutkinnonOsa.nimi
-          ? self.tutkinnonOsa.nimi[root.translations.activeLocale]
-          : ""
+        return self.tutkinnonOsa.nimi[root.translations.activeLocale]
       },
       get tutkinnonOsaTyyppi(): TutkinnonOsaType {
         return TutkinnonOsaType.HankittavaAmmatillinen

--- a/shared/models/HankittavaAmmatillinenTutkinnonOsa.ts
+++ b/shared/models/HankittavaAmmatillinenTutkinnonOsa.ts
@@ -42,7 +42,12 @@ export const HankittavaAmmatillinenTutkinnonOsa = types
     const root: LocaleRoot = getRoot(self)
     return {
       get otsikko(): JSX.Element | string {
-        return self.tutkinnonOsa.nimi[root.translations.activeLocale]
+        return (
+          self.tutkinnonOsa.nimi[root.translations.activeLocale] ||
+          self.tutkinnonOsa.koodi.nimi[root.translations.activeLocale] ||
+          self.tutkinnonOsa.nimi.fi ||
+          self.tutkinnonOsa.koodi.nimi.fi
+        )
       },
       get tutkinnonOsaTyyppi(): TutkinnonOsaType {
         return TutkinnonOsaType.HankittavaAmmatillinen

--- a/shared/models/HankittavaKoulutuksenOsa.ts
+++ b/shared/models/HankittavaKoulutuksenOsa.ts
@@ -34,9 +34,7 @@ export const HankittavaKoulutuksenOsa = types
         return TutkinnonOsaType.HankittavaKoulutuksenOsa
       },
       get otsikko(): JSX.Element | string {
-        return self.tutkinnonOsa && self.tutkinnonOsa.nimi
-          ? self.tutkinnonOsa.nimi[root.translations.activeLocale]
-          : "TUVA Koulutuksen Osa " + self.laajuus + " vkoa"
+        return self.tutkinnonOsa.nimi[root.translations.activeLocale]
       },
       get isValmis() {
         return new Date() >= new Date(self.loppu)

--- a/shared/models/HankittavaKoulutuksenOsa.ts
+++ b/shared/models/HankittavaKoulutuksenOsa.ts
@@ -34,7 +34,10 @@ export const HankittavaKoulutuksenOsa = types
         return TutkinnonOsaType.HankittavaKoulutuksenOsa
       },
       get otsikko(): JSX.Element | string {
-        return self.tutkinnonOsa.nimi[root.translations.activeLocale]
+        return (
+          self.tutkinnonOsa.nimi[root.translations.activeLocale] ||
+          self.tutkinnonOsa.nimi.fi
+        )
       },
       get isValmis() {
         return new Date() >= new Date(self.loppu)

--- a/shared/models/YhteinenTutkinnonOsa/AiemminHankitunYTOOsaAlue.ts
+++ b/shared/models/YhteinenTutkinnonOsa/AiemminHankitunYTOOsaAlue.ts
@@ -35,9 +35,7 @@ export const AiemminHankitunYTOOsaAlue = types
   )
   .views(self => ({
     get otsikko(): JSX.Element | string {
-      return self.osaAlueEnrichedData
-        ? self.osaAlueEnrichedData.osaAlueNimi
-        : ""
+      return self.osaAlueEnrichedData.osaAlueNimi
     },
     get osaamispisteet() {
       return self.osaAlueEnrichedData.laajuus

--- a/shared/models/YhteinenTutkinnonOsa/OsaAlueVastaus.tsx
+++ b/shared/models/YhteinenTutkinnonOsa/OsaAlueVastaus.tsx
@@ -1,12 +1,9 @@
-import React from "react"
 import { getRoot, Instance, types } from "mobx-state-tree"
 import {
   EPerusteetArviointi,
   EPerusteetNimi,
   EPerusteKoodi
 } from "../EPerusteetVastaus"
-import { GrAlert } from "react-icons/gr"
-import { IconInline } from "../../components/Icon"
 import { IRootStore } from "../../../virkailija/src/stores/RootStore"
 import { Locale } from "../../stores/TranslationStore"
 
@@ -15,18 +12,6 @@ const OsaamisTavoitteet = types.model({
   pakollinen: types.maybe(types.boolean),
   arviointi: types.maybeNull(EPerusteetArviointi)
 })
-
-const fallbackMessage = (
-  koodiUri: string | undefined,
-  message: string
-): JSX.Element => (
-  <span title={message}>
-    <IconInline>
-      <GrAlert size="20" color="#EC7123" />
-    </IconInline>
-    {koodiUri ? koodiUri.split("_")[1].toUpperCase() : ""}
-  </span>
-)
 
 export const OsaAlueVastaus = types
   .model("OsaAlueVastaus", {
@@ -40,17 +25,7 @@ export const OsaAlueVastaus = types
     const activeLocale: Locale = root.translations.activeLocale
     return {
       get osaAlueNimi(): JSX.Element | string {
-        if (!self.koodi && !self.koodiUri) return ""
-        return (
-          self.koodi?.nimi[activeLocale] ||
-          fallbackMessage(
-            self.koodiUri,
-            root.translations.messages[activeLocale][
-              "errors.OsaAlueVastaus.nimeaEiLoytynyt"
-            ] ||
-              "Osa-alueen nimen lataaminen ei onnistunut. Tämä on tilapäinen häiriö."
-          )
-        )
+        return self.koodi?.nimi[activeLocale]
       },
       get laajuus() {
         return self.osaamistavoitteet

--- a/shared/models/YhteinenTutkinnonOsa/OsaAlueVastaus.tsx
+++ b/shared/models/YhteinenTutkinnonOsa/OsaAlueVastaus.tsx
@@ -25,7 +25,12 @@ export const OsaAlueVastaus = types
     const activeLocale: Locale = root.translations.activeLocale
     return {
       get osaAlueNimi(): JSX.Element | string {
-        return self.koodi?.nimi[activeLocale]
+        return (
+          self.koodi?.nimi[activeLocale] ||
+          self.nimi[activeLocale] ||
+          self.koodi?.nimi.fi ||
+          self.nimi.fi
+        )
       },
       get laajuus() {
         return self.osaamistavoitteet

--- a/shared/models/YhteinenTutkinnonOsa/YhteisenTutkinnonOsanOsaAlue.ts
+++ b/shared/models/YhteinenTutkinnonOsa/YhteisenTutkinnonOsanOsaAlue.ts
@@ -36,9 +36,7 @@ export const YhteisenTutkinnonOsanOsaAlue = types
     const root: LocaleRoot = getRoot(self)
     return {
       get otsikko(): JSX.Element | string {
-        return self.osaAlueEnrichedData
-          ? self.osaAlueEnrichedData.osaAlueNimi
-          : ""
+        return self.osaAlueEnrichedData.osaAlueNimi
       },
 
       get osaamisvaatimukset() {

--- a/shared/models/helpers/AiemminHankitutTutkinnonOsatViews.ts
+++ b/shared/models/helpers/AiemminHankitutTutkinnonOsatViews.ts
@@ -1,16 +1,30 @@
-import { types } from "mobx-state-tree"
+import { types, getRoot } from "mobx-state-tree"
+import { LocaleRoot } from "models/helpers/LocaleRoot"
 import { getOtsikko } from "./getOtsikko"
 
 export const AiemminHankitutTutkinnonOsatViews = types
   .model({})
-  .views((self: any) => ({
-    get todentamisenProsessi() {
-      return {
-        koodiUri: self.valittuTodentamisenProsessiKoodiUri,
-        lahetettyArvioitavaksi:
-          self.tarkentavatTiedotOsaamisenArvioija.lahetettyArvioitavaksi
+  .views((self: any) => {
+    const root: LocaleRoot = getRoot(self)
+    return {
+      get todentamisenProsessi() {
+        return {
+          koodiUri: self.valittuTodentamisenProsessiKoodiUri,
+          lahetettyArvioitavaksi:
+            self.tarkentavatTiedotOsaamisenArvioija.lahetettyArvioitavaksi
+        }
+      },
+      opintoOtsikko: (ospLyhenne: string): JSX.Element | string => {
+        const translations = root.translations
+        const message =
+          translations.messages[translations.activeLocale][
+            "errors.OsaAlueVastaus.nimeaEiLoytynyt"
+          ]
+        return getOtsikko(
+          self,
+          ospLyhenne,
+          message || "tietojen lataaminen ePerusteet-palvelusta ei onnistunut."
+        )
       }
-    },
-    opintoOtsikko: (ospLyhenne: string): JSX.Element | string =>
-      getOtsikko(self, ospLyhenne)
-  }))
+    }
+  })

--- a/shared/models/helpers/HankittavatTutkinnonOsatViews.ts
+++ b/shared/models/helpers/HankittavatTutkinnonOsatViews.ts
@@ -39,13 +39,8 @@ export const HankittavatTutkinnonOsatViews = types
           return 0
         }
       },
-      opintoOtsikko(ospLyhenne: string): JSX.Element | string {
-        if (self.tyyppi !== TutkinnonOsaType.HankittavaKoulutuksenOsa) {
-          return getOtsikko(self, ospLyhenne)
-        } else {
-          return self.otsikko
-        }
-      },
+      opintoOtsikko: (ospLyhenne: string): JSX.Element | string =>
+        getOtsikko(self, ospLyhenne),
       hasNayttoOrHarjoittelujakso(type?: ShareType, moduleId?: string) {
         if (!moduleId && !type) {
           return false

--- a/shared/models/helpers/HankittavatTutkinnonOsatViews.ts
+++ b/shared/models/helpers/HankittavatTutkinnonOsatViews.ts
@@ -39,8 +39,18 @@ export const HankittavatTutkinnonOsatViews = types
           return 0
         }
       },
-      opintoOtsikko: (ospLyhenne: string): JSX.Element | string =>
-        getOtsikko(self, ospLyhenne),
+      opintoOtsikko: (ospLyhenne: string): JSX.Element | string => {
+        const translations = root.translations
+        const message =
+          translations.messages[translations.activeLocale][
+            "errors.OsaAlueVastaus.nimeaEiLoytynyt"
+          ]
+        return getOtsikko(
+          self,
+          ospLyhenne,
+          message || "tietojen lataaminen ePerusteet-palvelusta ei onnistunut."
+        )
+      },
       hasNayttoOrHarjoittelujakso(type?: ShareType, moduleId?: string) {
         if (!moduleId && !type) {
           return false

--- a/shared/models/helpers/LocaleRoot.ts
+++ b/shared/models/helpers/LocaleRoot.ts
@@ -1,7 +1,8 @@
-import { Locale } from "../../stores/TranslationStore"
+import { Locale, Translations } from "../../stores/TranslationStore"
 
 export interface LocaleRoot {
   translations: {
     activeLocale: Locale.FI | Locale.SV
+    messages: Translations
   }
 }

--- a/shared/models/helpers/getOtsikko.tsx
+++ b/shared/models/helpers/getOtsikko.tsx
@@ -2,13 +2,12 @@ import React from "react"
 import { GrAlert } from "react-icons/gr"
 import { IconInline } from "../../components/Icon"
 import { IHankittavaTutkinnonOsa } from "../../models/helpers/TutkinnonOsa"
-import { ITranslationStore } from "../../stores/TranslationStore"
 
-const fallbackMessage = (koodiUri: string): JSX.Element => {
+const fallbackMessage = (
+  koodiUri: string,
+  errormessage: string
+): JSX.Element => {
   const [codetype, code] = koodiUri.split("_")
-  //const errormessage = (translations.messages[translations.activeLocale]
-  //	["errors.OsaAlueVastaus.nimeaEiLoytynyt"] ||
-  const errormessage = "tietojen lataaminen ePerusteet-palvelusta epäonnistui."
   return (
     <span title={errormessage}>
       <IconInline>
@@ -21,20 +20,19 @@ const fallbackMessage = (koodiUri: string): JSX.Element => {
 
 export const getOtsikko = (
   model: IHankittavaTutkinnonOsa,
-  ospLyhenne: string
-): JSX.Element | string => {
-  return (
-    <span>
-      {model.otsikko
-        ? model.otsikko
-        : model.nimi
-        ? model.nimi
-        : model.tutkinnonOsaKoodiUri
-        ? fallbackMessage(model.tutkinnonOsaKoodiUri)
-        : model.osaAlueKoodiUri
-        ? fallbackMessage(model.osaAlueKoodiUri)
-        : fallbackMessage("moduleId: " + model.moduleId)}
-      {model.osaamispisteet ? ` ${model.osaamispisteet} ${ospLyhenne}` : ""}
-    </span>
-  )
-}
+  ospLyhenne: string,
+  errormessage: string
+): JSX.Element | string => (
+  <span>
+    {model.otsikko
+      ? model.otsikko
+      : model.nimi
+      ? model.nimi
+      : model.tutkinnonOsaKoodiUri
+      ? fallbackMessage(model.tutkinnonOsaKoodiUri, errormessage)
+      : model.osaAlueKoodiUri
+      ? fallbackMessage(model.osaAlueKoodiUri, errormessage)
+      : fallbackMessage("moduleId: " + model.moduleId, errormessage)}
+    {model.osaamispisteet ? ` ${model.osaamispisteet} ${ospLyhenne}` : ""}
+  </span>
+)

--- a/shared/models/helpers/getOtsikko.tsx
+++ b/shared/models/helpers/getOtsikko.tsx
@@ -1,11 +1,40 @@
 import React from "react"
+import { GrAlert } from "react-icons/gr"
+import { IconInline } from "../../components/Icon"
+import { IHankittavaTutkinnonOsa } from "../../models/helpers/TutkinnonOsa"
+import { ITranslationStore } from "../../stores/TranslationStore"
+
+const fallbackMessage = (koodiUri: string): JSX.Element => {
+  const [codetype, code] = koodiUri.split("_")
+  //const errormessage = (translations.messages[translations.activeLocale]
+  //	["errors.OsaAlueVastaus.nimeaEiLoytynyt"] ||
+  const errormessage = "tietojen lataaminen ePerusteet-palvelusta epäonnistui."
+  return (
+    <span title={errormessage}>
+      <IconInline>
+        <GrAlert size="20" color="#EC7123" />
+      </IconInline>
+      {codetype}: {code.toUpperCase()}
+    </span>
+  )
+}
 
 export const getOtsikko = (
-  model: { otsikko: JSX.Element | string; osaamispisteet: number },
+  model: IHankittavaTutkinnonOsa,
   ospLyhenne: string
-): JSX.Element => (
-  <span>
-    {model.otsikko}
-    {model.osaamispisteet ? ` ${model.osaamispisteet} ${ospLyhenne}` : ""}
-  </span>
-)
+): JSX.Element | string => {
+  return (
+    <span>
+      {model.otsikko
+        ? model.otsikko
+        : model.nimi
+        ? model.nimi
+        : model.tutkinnonOsaKoodiUri
+        ? fallbackMessage(model.tutkinnonOsaKoodiUri)
+        : model.osaAlueKoodiUri
+        ? fallbackMessage(model.osaAlueKoodiUri)
+        : fallbackMessage("moduleId: " + model.moduleId)}
+      {model.osaamispisteet ? ` ${model.osaamispisteet} ${ospLyhenne}` : ""}
+    </span>
+  )
+}


### PR DESCRIPTION
## Kuvaus muutoksista

- käsitellään tutkinnonosan haun vastaus eperusteista listana
- lisätään erilaisia vaihtoehtoja nimitiedolle, jos sitä ei löydy sieltä, mistä yleensä
- jos nimeä ei ollenkaan löydy, lisätään vaihtoehdoksi koodiUrin tai viime kädessä moduleId:n näyttäminen nimenä
- poistetaan kaikki sellainen logiikka, jossa otsikoksi palautetaan tyhjä merkkijono
- poistetaan kaikki sellainen logiikka, jossa merkkijonon olemassaolo päätellään jostain muusta kuin siitä, onko kyseinen merkkijono ei-tyhjä (esim. model-olioiden olemassaolosta jotka on kuitenkin aina olemassa)
- siirretään fallback-logiikka getOtsikko()-funktioon, jossa se vaikuttaa kaikkiin tutkinnonosiin eikä ainoastaan yhteisten tutkinnonosien osa-alueisiin

https://jira.eduuni.fi/browse/OY-4449

## Muistilista PR:n tekijälle ja katselmoijille

### Ennen asettamista katselmointiin
  - [x] Build onnistuu ilman virheitä
  - [ ] Toiminnallisuuden kattavat yksikkötestit on tehty osana PR:ia
  - [x] PR:n sisältämät muutokset noudattavat [sovittuja koodikäytänteitä](../doc/code-guidelines.md)
  - [x] Koodi on riittävästi dokumentoitu tai se on muuten yksiselitteistä
  - [x] Nimet (muuttujat, funktiot, ...) kuvaavat koodia hyvin

❗ **Katselmoijat tarkastavat, että yllä mainitut kohdat toteutuvat**

### Ennen mergeämistä `master`-haaralle
  - [x] Vähintään yksi kehittäjä on katselmoinut ja hyväksynyt muutokset
    - Jos muutoksilla voi jotain rikkoessaan olla kauaskantoiset vaikutukset, kannattaa muutokset hyväksyttää useammalla katselmoijalla
  - [ ] Katselmoijien esittämät muutosehdotukset on huomioitu
  - [ ] Muutokset on testattu QA-ympäristössä
  - [ ] Yli jääneet kehityskohteet on tiketöity
