### PR TITLE
EH-1546: Map changed API response to ePerusteetVastaus

### DIFF
--- a/shared/models/EPerusteetVastaus.ts
+++ b/shared/models/EPerusteetVastaus.ts
@@ -1,64 +1,73 @@
 import { types } from "mobx-state-tree"
 
-const Otsikko = types.model({
+const EPerusteetText = types.model("EPerusteetText", {
   fi: types.optional(types.string, ""),
   sv: types.optional(types.string, "")
 })
 
-const Kriteeri = types.model({
-  fi: types.optional(types.string, ""),
-  sv: types.optional(types.string, "")
-})
+const defaultText = { fi: "", sv: "" }
 
-const OsaamistasonKriteeri = types.model({
-  osaamistaso: types.optional(types.string, ""),
-  kriteerit: types.array(Kriteeri)
-})
+const OsaamistasonKriteeri = types
+  .model("OsaamistasonKriteeri", {
+    osaamistaso: types.optional(types.string, ""),
+    kriteerit: types.array(EPerusteetText)
+  })
+  .preProcessSnapshot(sn => ({
+    ...sn,
+    osaamistaso:
+      typeof sn.osaamistaso === "string"
+        ? sn.osaamistaso
+        : typeof sn.osaamistaso === "object" && sn.osaamistaso
+        ? // the syntax is needed because of a bug in typescript
+          // https://github.com/microsoft/TypeScript/issues/42999
+          /* eslint dot-notation: "off" */
+          sn.osaamistaso["koodi"]["arvo"] || "" + sn.osaamistaso["id"]
+        : ""
+  }))
 
-const ArvioinninKohde = types.model({
-  otsikko: types.maybeNull(Otsikko),
-  arviointiAsteikko: types.optional(types.string, ""),
-  osaamistasonKriteerit: types.array(OsaamistasonKriteeri)
-})
+const ArvioinninKohde = types
+  .model("ArvioinninKohde", {
+    otsikko: types.optional(types.maybeNull(EPerusteetText), defaultText),
+    arviointiAsteikko: types.optional(types.string, ""),
+    osaamistasonKriteerit: types.array(OsaamistasonKriteeri)
+  })
+  .preProcessSnapshot(sn => ({
+    ...sn,
+    arviointiAsteikko:
+      typeof sn.arviointiAsteikko === "string"
+        ? sn.arviointiAsteikko
+        : typeof sn.arviointiAsteikko === "object" && sn.arviointiAsteikko
+        ? // the syntax is needed because of a bug in typescript
+          // https://github.com/microsoft/TypeScript/issues/42999
+          /* eslint dot-notation: "off" */
+          "" + sn.arviointiAsteikko["id"]
+        : ""
+  }))
 
-const ArvioinninKohdealue = types.model({
-  otsikko: types.optional(Otsikko, {}),
+const ArvioinninKohdealue = types.model("ArvioinninKohdealue", {
+  otsikko: types.optional(EPerusteetText, defaultText),
   arvioinninKohteet: types.array(ArvioinninKohde)
 })
 
-export const EPerusteetArviointi = types.model({
+export const EPerusteetArviointi = types.model("EPerusteetArviointi", {
   id: types.optional(types.number, 0),
   arvioinninKohdealueet: types.maybeNull(types.array(ArvioinninKohdealue))
 })
 
-const EPerusteetAmmattitaitovaatimukset = types.model({
-  fi: types.optional(types.string, ""),
-  sv: types.optional(types.string, "")
-})
+export const EPerusteetNimi = EPerusteetText
 
-const EPerusteetAmmattitaidonOsoittamistavat = types.model({
-  fi: types.optional(types.string, ""),
-  sv: types.optional(types.string, "")
-})
-
-export const EPerusteetNimi = types.model({
-  fi: types.optional(types.string, ""),
-  sv: types.optional(types.string, "")
-})
-
-export const EPerusteKoodi = types.model({
-  nimi: types.optional(EPerusteetNimi, {})
+export const EPerusteKoodi = types.model("EPerusteKoodi", {
+  nimi: types.optional(EPerusteetNimi, defaultText)
 })
 
 export const EPerusteetVastaus = types.model("EPerusteet", {
   id: types.optional(types.number, 0),
   koodiUri: types.optional(types.string, ""),
   arviointi: types.maybeNull(EPerusteetArviointi),
-  ammattitaitovaatimukset: types.maybeNull(EPerusteetAmmattitaitovaatimukset),
-  ammattitaidonOsoittamistavat: types.maybeNull(
-    EPerusteetAmmattitaidonOsoittamistavat
-  ),
-  nimi: types.optional(EPerusteetNimi, {}),
-  koodi: types.optional(EPerusteKoodi, {}),
-  koulutuksenOsaViiteId: types.optional(types.number, 0)
+  ammattitaitovaatimukset: types.optional(EPerusteetText, defaultText),
+  ammattitaidonOsoittamistavat: types.optional(EPerusteetText, defaultText),
+  nimi: types.optional(EPerusteetNimi, defaultText),
+  koodi: types.optional(EPerusteKoodi, { nimi: defaultText }),
+  koulutuksenOsaViiteId: types.optional(types.number, 0),
+  muokattu: types.optional(types.number, 0)
 })


### PR DESCRIPTION
## Kuvaus muutoksista

Vaikuttaa siltä, että ePerusteiden vastaukset ovat muuttuneet hiukan ja kun ne viedään EPerusteetVastaus-modeliin, siitä tulee mäppäysvirheitä.  Ongelmia aiheuttavat sekä kentät, jotka eivät aiemmin ole voineet olla `null`, että osaamistaso- ja arviointiKriteerit-kentät, joiden muoto on muuttunut merkkijonosta rakenteiseksi dataksi.

Näiden korjaaminen sai tutkinnonosien nimet näkymään ainakin deviympäristössä: https://jira.eduuni.fi/browse/EH-1546?focusedId=247521&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-247521

https://jira.eduuni.fi/browse/EH-1546

## Muistilista PR:n tekijälle ja katselmoijille

### Ennen asettamista katselmointiin
  - [ ] Build onnistuu ilman virheitä
  - [ ] Toiminnallisuuden kattavat yksikkötestit on tehty osana PR:ia
  - [ ] PR:n sisältämät muutokset noudattavat [sovittuja koodikäytänteitä](../doc/code-guidelines.md)
  - [ ] Koodi on riittävästi dokumentoitu tai se on muuten yksiselitteistä
  - [ ] Nimet (muuttujat, funktiot, ...) kuvaavat koodia hyvin

❗ **Katselmoijat tarkastavat, että yllä mainitut kohdat toteutuvat**

### Ennen mergeämistä `master`-haaralle
  - [ ] Vähintään yksi kehittäjä on katselmoinut ja hyväksynyt muutokset
    - Jos muutoksilla voi jotain rikkoessaan olla kauaskantoiset vaikutukset, kannattaa muutokset hyväksyttää useammalla katselmoijalla
  - [ ] Katselmoijien esittämät muutosehdotukset on huomioitu
  - [ ] Muutokset on testattu QA-ympäristössä
  - [ ] Yli jääneet kehityskohteet on tiketöity
