### PR TITLE
OY-4489: Käytä session storagea hoksin välivarastona

### DIFF
--- a/virkailija/src/routes/LuoHOKS.tsx
+++ b/virkailija/src/routes/LuoHOKS.tsx
@@ -100,8 +100,8 @@ export class LuoHOKS extends React.Component<LuoHOKSProps, LuoHOKSState> {
       formData = {},
       errors = [],
       errorsByStep = {}
-    } = window.localStorage.getItem("hoks")
-      ? JSON.parse(window.localStorage.getItem("hoks") || "")
+    } = window.sessionStorage.getItem("hoks")
+      ? JSON.parse(window.sessionStorage.getItem("hoks") || "")
       : {}
     this.setState({
       formData,
@@ -163,7 +163,7 @@ export class LuoHOKS extends React.Component<LuoHOKSProps, LuoHOKSState> {
       }),
       () => {
         const { errorsByStep } = this.state
-        window.localStorage.setItem(
+        window.sessionStorage.setItem(
           "hoks",
           JSON.stringify({ formData, errors, errorsByStep })
         )
@@ -217,7 +217,7 @@ export class LuoHOKS extends React.Component<LuoHOKSProps, LuoHOKSState> {
         message: undefined,
         userEnteredText: false
       })
-      window.localStorage.removeItem("hoks")
+      window.sessionStorage.removeItem("hoks")
     } else {
       this.setState({ success: false, message: undefined })
       const { intl } = this.context
@@ -250,7 +250,7 @@ export class LuoHOKS extends React.Component<LuoHOKSProps, LuoHOKSState> {
       isRoot: isRoot(rootKeys),
       koodiUriSelected: koodiUriSelected(this, () => {
         const { formData, errors, errorsByStep } = this.state
-        window.localStorage.setItem(
+        window.sessionStorage.setItem(
           "hoks",
           JSON.stringify({ formData, errors, errorsByStep })
         )
@@ -279,7 +279,7 @@ export class LuoHOKS extends React.Component<LuoHOKSProps, LuoHOKSState> {
         clearModalOpen: false
       },
       () => {
-        window.localStorage.setItem(
+        window.sessionStorage.setItem(
           "hoks",
           JSON.stringify({ formData: {}, errors: [], errorsByStep: {} })
         )

--- a/virkailija/translations.json
+++ b/virkailija/translations.json
@@ -124,6 +124,7 @@
     "koulutuksenJarjestaja.tutkintoTitle": "Tutkinto tai koulutus",
     "luoHoks.luontiOnnistui": "HOKS luotiin onnistuneesti",
     "luoHoks.vaaditutKentat": "Vaaditut kentät",
+    "luoHoks.haluatkoPoistua": "Tietoja ei ole vielä tallennettu. Haluatko silti poistua HOKSin luonnista?",
     "muokkaaHoks.tallennusOnnistui": "HOKS tallennettiin onnistuneesti",
     "notification.Opiskelijapalaute.resendPalaute.success": "Sähköposti opiskelijapalautteesta lähetetään osoitteeseen {sahkoposti}.",
     "notification.piilotaNotifikaatioAriaLabel": "Piilota ilmoitus",


### PR DESCRIPTION
Vaihdetaan ehoks-ui käyttämään session storagea välivarastona hoksia luodessa. Aiemmin käytössä on ollut local storage, jolla ei ole vanhenemisaikaa. On siis mahdollista, että syötettyä (tallentamatonta) henkilötietoa on voinut jäädä selaimen local storageen pidemmäksikin aikaa. Session storage tyhjenee, kun selaimen kyseinen välilehti suljetaan.

Tällä muutoksella on sellainen sivuvaikutus, että jos aiemmin käyttäjä on ollut syöttämässä uuden hoksin tietoja selaimen yhdellä välilehdellä ja on avannut ehoksin toiseen välilehteen, hän on voinut jatkaa tuon kyseisen hoksin täyttöä toisella välilehdellä (tai jopa uudelleenkirjautumisen jälkeenkin uudessa ikkunassa). Muutoksen käyttöönoton jälkeen tämä ei enää ole mahdollista, vaan uuden hoksin syöttäminen pitää tehdä loppuun sillä samalla välilehdellä, jolla se on aloitettukin.