### PR TITLE
OY-4352: Small fixes that were included in #452 but not in #459

### DIFF
--- a/shared/models/HOKS.ts
+++ b/shared/models/HOKS.ts
@@ -351,10 +351,10 @@ export const HOKS = types
         const isOsittainen = self.opiskeluOikeus.isOsittainen
 
         const translations = getRoot<IRootStore>(self).translations
-        const activeLocale: Locale = translations.activeLocale
-        const osittainenText: string =
-          translations.messages[activeLocale]["opiskeluoikeus.osittainen"] ||
-          "osittainen"
+        const messages = translations.messages[translations.activeLocale]
+        const osittainenText: string = messages
+          ? messages["opiskeluoikeus.osittainen"]
+          : "osittainen"
         const tutkinnonNimi = self.opiskeluOikeus.suoritukset.length
           ? self.opiskeluOikeus.suoritukset[0].koulutusmoduuli.nimi
           : ""

--- a/shared/stores/TranslationStore/defaultMessages.json
+++ b/shared/stores/TranslationStore/defaultMessages.json
@@ -216,8 +216,18 @@
   },
   {
     "locale": "fi",
+    "key": "header.tietojenTallennusLink",
+    "value": "Uusi HOKS"
+  },
+  {
+    "locale": "fi",
     "key": "header.valtuudet",
     "value": "(Valtuudet)"
+  },
+  {
+    "locale": "fi",
+    "key": "header.yllapitoLink",
+    "value": "Ylläpito"
   },
   {
     "locale": "fi",
@@ -261,6 +271,11 @@
   },
   {
     "locale": "fi",
+    "key": "koulutuksenJarjestaja.eiOpiskelijoitaLabel",
+    "value": "Näillä hakuehdoilla ei löytynyt yhtään opiskelijaa."
+  },
+  {
+    "locale": "fi",
     "key": "koulutuksenJarjestaja.hakuAriaLabel",
     "value": "Hae opiskelijaa"
   },
@@ -276,13 +291,53 @@
   },
   {
     "locale": "fi",
+    "key": "koulutuksenJarjestaja.haunSivutuksenEdellinen",
+    "value": "Edellinen"
+  },
+  {
+    "locale": "fi",
+    "key": "koulutuksenJarjestaja.haunSivutuksenSeuraava",
+    "value": "Seuraava"
+  },
+  {
+    "locale": "fi",
+    "key": "koulutuksenJarjestaja.hoksIdTitle",
+    "value": "eHOKS-id"
+  },
+  {
+    "locale": "fi",
+    "key": "koulutuksenJarjestaja.hyvaksyttyTitle",
+    "value": "Ens. hyv."
+  },
+  {
+    "locale": "fi",
     "key": "koulutuksenJarjestaja.jarjestaTitle",
     "value": "Järjestä"
   },
   {
     "locale": "fi",
+    "key": "koulutuksenJarjestaja.lkmTitle",
+    "value": "Lkm"
+  },
+  {
+    "locale": "fi",
     "key": "koulutuksenJarjestaja.meneHakutuloksienSivulleAriaLabel",
     "value": "Mene hakutuloksien sivulle {page}"
+  },
+  {
+    "locale": "fi",
+    "key": "koulutuksenJarjestaja.opiskelijaTitle",
+    "value": "Opiskelijan nimi"
+  },
+  {
+    "locale": "fi",
+    "key": "koulutuksenJarjestaja.osaamisalaTitle",
+    "value": "Osaamisala"
+  },
+  {
+    "locale": "fi",
+    "key": "koulutuksenJarjestaja.paivitettyTitle",
+    "value": "Päivitetty"
   },
   {
     "locale": "fi",
@@ -328,6 +383,16 @@
     "locale": "fi",
     "key": "koulutuksenJarjestaja.tavoite.suunnitelmaJatkoOpintoihinTitle",
     "value": "Suunnitelma jatko-opintoihin siirtymisestä"
+  },
+  {
+    "locale": "fi",
+    "key": "koulutuksenJarjestaja.title",
+    "value": "Järjestä"
+  },
+  {
+    "locale": "fi",
+    "key": "koulutuksenJarjestaja.tutkintoTitle",
+    "value": "Tutkinto tai koulutus"
   },
   {
     "locale": "fi",

--- a/virkailija/src/routes/KoulutuksenJarjestaja.tsx
+++ b/virkailija/src/routes/KoulutuksenJarjestaja.tsx
@@ -89,8 +89,7 @@ export class KoulutuksenJarjestaja extends React.Component<
             window.scrollTo(0, 0)
           })
         }
-      },
-      { fireImmediately: true }
+      }
     )
   }
 


### PR DESCRIPTION
Cherry-pickattu seuraavat commitit:
- https://github.com/Opetushallitus/ehoks-ui/pull/452/commits/5e846015c8acebf385a9f38a7970d905eaad5c53 (korjaa tähän liittyvän konsoliin tuleen virheen)
- https://github.com/Opetushallitus/ehoks-ui/pull/452/commits/308d68dd2c34c0e4e414a92ef707f9381c63ec36 (korjaa jokusen herjan konsoliin käännöstekstien puuttumisesta)
- https://github.com/Opetushallitus/ehoks-ui/pull/452/commits/433ac921a5c4c143df106af8bcabc53d7dc58ef7 (`fireImmediately`-lippu tais olla turha, ainakin mun aiempien testailujen mukaan)

Commitin https://github.com/Opetushallitus/ehoks-ui/pull/452/commits/1244dd1e9b861fa160913c34a57e6587028affee jätin pois, koska en testatessa nähnyt consolissa ainakaan ylimääräisiä virheitä :thinking: 