### PR TITLE
EH-1682: Käytä rajapinnan oppilaitos-oidia pääkäyttäjän raporttinäkymässä

### DIFF
--- a/virkailija/src/routes/KoulutuksenJarjestaja.tsx
+++ b/virkailija/src/routes/KoulutuksenJarjestaja.tsx
@@ -50,6 +50,7 @@ const SearchableTable = styled(Table)<{ children: React.ReactNode }>`
 const Spinner = styled(LoadingSpinner)`
   position: absolute;
   right: 0;
+  top: 20px;
 `
 
 interface KoulutuksenJarjestajaProps {

--- a/virkailija/src/routes/KoulutuksenJarjestaja/KoulutuksenJarjestajaHOKS.tsx
+++ b/virkailija/src/routes/KoulutuksenJarjestaja/KoulutuksenJarjestajaHOKS.tsx
@@ -56,9 +56,14 @@ const HelpButton = styled(HelpPopup)`
   margin: 0 0 0 20px;
 `
 
+const RelativePaddedContent = styled(PaddedContent)`
+  position: relative;
+`
+
 const Spinner = styled(LoadingSpinner)`
   position: absolute;
-  right: 0;
+  top: 20px;
+  right: 20px;
 `
 
 export interface KoulutuksenJarjestajaHOKSProps {
@@ -137,8 +142,8 @@ export const KoulutuksenJarjestajaHOKS = inject("store")(
       <React.Fragment>
         <NavigationContainer>
           <Container>
-            {loading && <Spinner />}
-            <PaddedContent>
+            <RelativePaddedContent>
+              {loading && <Spinner />}
               {suunnitelmat.length > 1 && (
                 <Timestamp>
                   <StudentLink to={oppijaPath}>
@@ -190,7 +195,7 @@ export const KoulutuksenJarjestajaHOKS = inject("store")(
                   </SectionItem>
                 </SectionItems>
               </NaviContainer>
-            </PaddedContent>
+            </RelativePaddedContent>
           </Container>
         </NavigationContainer>
 

--- a/virkailija/src/routes/KoulutuksenJarjestaja/Opiskelija.tsx
+++ b/virkailija/src/routes/KoulutuksenJarjestaja/Opiskelija.tsx
@@ -39,9 +39,7 @@ const TopContainer = styled("div")`
 `
 
 const Spinner = styled(LoadingSpinner)`
-  position: absolute;
-  right: 0;
-  top: 20px;
+  margin: 20px auto;
 `
 
 export interface OpiskelijaProps {

--- a/virkailija/src/routes/Raportit.tsx
+++ b/virkailija/src/routes/Raportit.tsx
@@ -165,6 +165,7 @@ export interface TpjRow {
   hoksEid: string
   opiskeluoikeusOid: string
   oppijaOid: string
+  oppilaitosOid: string
   hankkimistapaTyyppi: string
   alkupvm: string
   loppupvm: string
@@ -374,7 +375,8 @@ class RaportitInner extends React.Component<RaportitProps> {
         break
     }
     return oppijaOid.length && hoksEid.length
-      ? `/ehoks-virkailija-ui/koulutuksenjarjestaja/${oppilaitosOid}/oppija/${oppijaOid}/${hoksEid}`
+      ? `/ehoks-virkailija-ui/koulutuksenjarjestaja/${row.oppilaitosOid ||
+          oppilaitosOid}/oppija/${oppijaOid}/${hoksEid}`
       : "/ehoks-virkailija-ui/raportit"
   }
 


### PR DESCRIPTION
Jotta pääkäyttäjän raporttinäkymän linkit HOKSeihin toimivat oikein, pitää oppilaitos-oid välittää APIsta käyttöliittymälle.

Korjasin samalla myös spinnerin asettelun HOKSia ladattaessa.