### PR TITLE
EH-1844: Remove resend button

### DIFF
--- a/oppija/translations.json
+++ b/oppija/translations.json
@@ -258,6 +258,7 @@
     "tavoitteet.opiskelijapalauteEiPalautteita": "Ei aktiivisia palautteita",
     "tavoitteet.opiskelijapalautePaattymispvmTitle": "Vastaamisajan päättymispäivä",
     "tavoitteet.opiskelijapalauteResendButton": "Lähetä linkki opiskelijapalautekyselyyn uudestaan",
+    "tavoitteet.opiskelijapalauteResendDisabled": "Palautekyselyn uudelleenlähetys on väliaikaisesti poistettu käytöstä järjestelmäkehityksen ajaksi.",
     "tavoitteet.opiskelijapalauteSahkopostiTitle": "Opiskelijan sähköpostiosoite",
     "tavoitteet.opiskelijapalauteTila": "Viesti on lähetetty {date} opiskelijalle",
     "tavoitteet.opiskelijapalauteTilaTitle": "Opiskelijapalautteen tila",

--- a/shared/stores/TranslationStore/defaultMessages.json
+++ b/shared/stores/TranslationStore/defaultMessages.json
@@ -696,6 +696,11 @@
   },
   {
     "locale": "fi",
+    "key": "tavoitteet.opiskelijapalauteResendDisabled",
+    "value": "Palautekyselyn uudelleenlähetys on väliaikaisesti poistettu käytöstä järjestelmäkehityksen ajaksi."
+  },
+  {
+    "locale": "fi",
     "key": "tavoitteet.opiskelijapalauteSahkopostiTitle",
     "value": "Opiskelijan sähköpostiosoite"
   },

--- a/virkailija/src/routes/KoulutuksenJarjestaja/Opiskelijapalaute.tsx
+++ b/virkailija/src/routes/KoulutuksenJarjestaja/Opiskelijapalaute.tsx
@@ -8,7 +8,6 @@ import { FormattedDate } from "components/FormattedDate"
 import { IOpiskelijapalauteTila } from "models/OpiskelijapalauteTila"
 import { Button } from "components/Button"
 import { IRootStore } from "../../stores/RootStore"
-import { appendCommonHeaders } from "fetchUtils"
 
 export interface OpiskelijapalauteProps {
   store?: IRootStore
@@ -20,51 +19,9 @@ export interface OpiskelijapalauteProps {
   palauteTilat: IOpiskelijapalauteTila[]
 }
 
-interface ResendParameters {
-  tyyppi: string
-}
-
 export const Opiskelijapalaute = inject("store")(
   observer((props: OpiskelijapalauteProps) => {
     const { notifications } = props.store!
-    const resendPalaute =
-      (data: ResendParameters) => async (): Promise<void> => {
-        const { hoksID, oppijaOid } = props
-
-        const response: Response = await window.fetch(
-          `/ehoks-virkailija-backend/api/v1/virkailija/oppijat/${oppijaOid}/hoksit/${hoksID}/resend-palaute`,
-          {
-            method: "POST",
-            credentials: "include",
-            headers: appendCommonHeaders(
-              new Headers({
-                Accept: "application/json; charset=utf-8",
-                "Content-Type": "application/json"
-              })
-            ),
-            body: JSON.stringify(data)
-          }
-        )
-
-        if (response.ok) {
-          const json = await response.json()
-          notifications.addNotifications([
-            {
-              title: "Opiskelijapalaute.resendPalaute.success",
-              source: "Opiskelijapalaute",
-              sahkoposti: json.data.sahkoposti,
-              default:
-                "Sähköposti opiskelijapalautteesta lähetetään osoitteeseen {sahkoposti}.",
-              tyyppi: "success"
-            }
-          ])
-        } else {
-          notifications.addError(
-            "Opiskelijapalaute.resendPalaute",
-            response.statusText
-          )
-        }
-      }
 
     useEffect(
       () => () => {
@@ -173,20 +130,30 @@ export const Opiskelijapalaute = inject("store")(
                     </tr>
                   </tbody>
                 </InfoTable>
-                {!(
-                  Date.now() > new Date(palauteTila.voimassaLoppupvm).getTime()
-                ) && (
-                  <Button
-                    onClick={resendPalaute({
-                      tyyppi: palauteTila.tyyppi
-                    })}
-                  >
-                    <FormattedMessage
-                      id="tavoitteet.opiskelijapalauteResendButton"
-                      defaultMessage="Lähetä linkki opiskelijapalautekyselyyn uudestaan"
-                    />
-                  </Button>
-                )}
+                {
+                  // FIXME: resend button disabled until the resend functionality is
+                  // restored in palaute-backend.  (The functionality also needs to be
+                  // fixed: it should add a resend request to the palaute instead of
+                  // purging information about the already sent message.)
+                  !(
+                    Date.now() >
+                    new Date(palauteTila.voimassaLoppupvm).getTime()
+                  ) && (
+                    <Button disabled>
+                      <FormattedMessage
+                        id="tavoitteet.opiskelijapalauteResendButton"
+                        defaultMessage="Lähetä linkki opiskelijapalautekyselyyn uudestaan"
+                      />
+                    </Button>
+                  )
+                }
+                <FormattedMessage
+                  id="tavoitteet.opiskelijapalauteResendDisabled"
+                  defaultMessage={
+                    "Palautekyselyn uudelleenlähetys on väliaikaisesti " +
+                    "poistettu käytöstä järjestelmäkehityksen ajaksi."
+                  }
+                />
               </React.Fragment>
             )
           )

--- a/virkailija/translations.json
+++ b/virkailija/translations.json
@@ -249,6 +249,7 @@
     "tavoitteet.opiskelijapalauteEiPalautteita": "Ei aktiivisia vastauslinkkejä",
     "tavoitteet.opiskelijapalautePaattymispvmTitle": "Vastaamisajan päättymispäivä",
     "tavoitteet.opiskelijapalauteResendButton": "Lähetä linkki opiskelijapalautekyselyyn uudelleen",
+    "tavoitteet.opiskelijapalauteResendDisabled": "Palautekyselyn uudelleenlähetys on väliaikaisesti poistettu käytöstä järjestelmäkehityksen ajaksi.",
     "tavoitteet.opiskelijapalauteSahkopostiTitle": "Opiskelijan sähköpostiosoite",
     "tavoitteet.opiskelijapalauteTila.lahetetty": "Viesti lähetetty opiskelijalle {date}",
     "tavoitteet.opiskelijapalauteTila.lahetys_epaonnistunut": "Viestin lähetys opiskelijalle epäonnistunut {date}",


### PR DESCRIPTION
## Kuvaus muutoksista

opiskelijapalautteen uudelleenlähetys-API ei toimi, joten poistetaan hämäävä nappula käyttöliittymästä joka ei kuitenkaan tekisi mitään.

https://jira.eduuni.fi/browse/EH-1844

## Muistilista PR:n tekijälle ja katselmoijille

### Ennen asettamista katselmointiin
  - [ ] Build onnistuu ilman virheitä
  - [ ] Toiminnallisuuden kattavat yksikkötestit on tehty osana PR:ia
  - [ ] Toteutuksessa käytetyt komponentit on katsottu, voidaanko käyttää [ODS:n](https://github.com/Opetushallitus/oph-design-system) vastaavia
  - [ ] Koodi on riittävästi dokumentoitu tai se on muuten yksiselitteistä
  - [ ] Nimet (muuttujat, funktiot, ...) kuvaavat koodia hyvin

❗ **Katselmoijat tarkastavat, että yllä mainitut kohdat toteutuvat**

### Ennen mergeämistä `master`-haaralle
  - [ ] Vähintään yksi kehittäjä on katselmoinut ja hyväksynyt muutokset
    - Jos muutoksilla voi jotain rikkoessaan olla kauaskantoiset vaikutukset, kannattaa muutokset hyväksyttää useammalla katselmoijalla
  - [ ] Katselmoijien esittämät muutosehdotukset on huomioitu
  - [ ] Muutokset on testattu QA-ympäristössä
    - [ ] Testausohje kirjoitettu
    - [ ] Testaus delegoitu OPH:lle mikäli mahdollista
  - [ ] Yli jääneet kehityskohteet on tiketöity
