### PR TITLE
EH-1906: tutkinnon-osan-perusteen-diaarinro at the right place in UI

### DIFF
--- a/virkailija/src/routes/LuoHOKS/uiSchema.ts
+++ b/virkailija/src/routes/LuoHOKS/uiSchema.ts
@@ -81,6 +81,7 @@ const fullUiSchema = (options: UiSchemaOptions): { [key: string]: any } => ({
       "ui:order": [
         "tutkinnon-osa-koodi-uri",
         "tutkinnon-osa-koodi-versio",
+        "tutkinnon-osan-perusteen-diaarinro",
         "valittu-todentamisen-prosessi-koodi-uri",
         "valittu-todentamisen-prosessi-koodi-versio",
         "koulutuksen-jarjestaja-oid",
@@ -524,6 +525,7 @@ const fullUiSchema = (options: UiSchemaOptions): { [key: string]: any } => ({
       "ui:order": [
         "tutkinnon-osa-koodi-uri",
         "tutkinnon-osa-koodi-versio",
+        "tutkinnon-osan-perusteen-diaarinro",
         "vaatimuksista-tai-tavoitteista-poikkeaminen",
         "koulutuksen-jarjestaja-oid",
         "opetus-ja-ohjaus-maara",

--- a/virkailija/src/routes/MuokkaaHOKS/uiSchema.ts
+++ b/virkailija/src/routes/MuokkaaHOKS/uiSchema.ts
@@ -88,6 +88,7 @@ const fullUiSchema = (options: UiSchemaOptions): { [key: string]: any } => ({
       "ui:order": [
         "tutkinnon-osa-koodi-uri",
         "tutkinnon-osa-koodi-versio",
+        "tutkinnon-osan-perusteen-diaarinro",
         "valittu-todentamisen-prosessi-koodi-uri",
         "valittu-todentamisen-prosessi-koodi-versio",
         "koulutuksen-jarjestaja-oid",
@@ -541,6 +542,7 @@ const fullUiSchema = (options: UiSchemaOptions): { [key: string]: any } => ({
       "ui:order": [
         "tutkinnon-osa-koodi-uri",
         "tutkinnon-osa-koodi-versio",
+        "tutkinnon-osan-perusteen-diaarinro",
         "vaatimuksista-tai-tavoitteista-poikkeaminen",
         "koulutuksen-jarjestaja-oid",
         "opetus-ja-ohjaus-maara",


### PR DESCRIPTION
## Kuvaus muutoksista

Huolehditaan, että perusteen diaarinumero (joka on osa tutkinnonosan tunnistetta) on johdonmukaisessa paikassa tutkinnonosan koodin vieressä.

https://jira.eduuni.fi/browse/EH-1906

## Muistilista PR:n tekijälle ja katselmoijille

### Ennen asettamista katselmointiin
  - [x] Build onnistuu ilman virheitä
  - [ ] Toiminnallisuuden kattavat yksikkötestit on tehty osana PR:ia
  - [x] Toteutuksessa käytetyt komponentit on katsottu, voidaanko käyttää [ODS:n](https://github.com/Opetushallitus/oph-design-system) vastaavia
  - [x] Koodi on riittävästi dokumentoitu tai se on muuten yksiselitteistä
  - [x] Nimet (muuttujat, funktiot, ...) kuvaavat koodia hyvin

❗ **Katselmoijat tarkastavat, että yllä mainitut kohdat toteutuvat**

### Ennen mergeämistä `master`-haaralle
  - [ ] Vähintään yksi kehittäjä on katselmoinut ja hyväksynyt muutokset
    - Jos muutoksilla voi jotain rikkoessaan olla kauaskantoiset vaikutukset, kannattaa muutokset hyväksyttää useammalla katselmoijalla
  - [ ] Katselmoijien esittämät muutosehdotukset on huomioitu
  - [ ] Muutokset on testattu QA-ympäristössä
    - [ ] Testausohje kirjoitettu
    - [ ] Testaus delegoitu OPH:lle mikäli mahdollista
  - [x] Yli jääneet kehityskohteet on tiketöity
