### PR TITLE
EH-1996: don't show koulutustoimija orgs in org switch dropdown

### DIFF
--- a/shared/fetchUtils.ts
+++ b/shared/fetchUtils.ts
@@ -113,7 +113,10 @@ export function fetchUtils(
 export const mockFetch =
   (apiUrl: (path: string) => string, version = 0) =>
   (url: string): Promise<Response> => {
-    const path = url.replace(apiUrl(""), "")
+    const path = url.replace(apiUrl(""), "").replace(/\?.*/, "")
+    const responseJson = import(
+      `stores/mocks/${path.replace(/\/|-/g, "_")}${version}.json`
+    )
     const mockResponse = {
       arrayBuffer: () => Promise.resolve(new ArrayBuffer(0)),
       formData: () => Promise.resolve(new FormData()),
@@ -129,8 +132,7 @@ export const mockFetch =
       body: null,
       bodyUsed: false,
       clone: () => mockResponse,
-      json: () =>
-        import(`stores/mocks/${path.replace(/\/|-/g, "_")}${version}.json`),
+      json: () => responseJson,
       ok: true,
       statusText: "Error"
     }

--- a/shared/types/Organisation.ts
+++ b/shared/types/Organisation.ts
@@ -2,7 +2,8 @@ import { Instance, types } from "mobx-state-tree"
 
 export const OrganisationModel = types.model("Organisation", {
   oid: types.string,
-  nimi: types.map(types.string)
+  nimi: types.map(types.string),
+  tyypit: types.optional(types.array(types.string), [])
 })
 
 export type IOrganisation = Instance<typeof OrganisationModel>

--- a/virkailija/src/stores/SessionStore.ts
+++ b/virkailija/src/stores/SessionStore.ts
@@ -98,9 +98,20 @@ export const SessionStore = types
           }),
           { headers: appendCallerId() }
         )
-        self.organisations = organisationsData.data.map((o: IOrganisation) => ({
+        const orgsWithoutKoulutustoimija = organisationsData.data.filter(
+          (o: IOrganisation) =>
+            (o.tyypit || []).findIndex(t =>
+              /organisaatiotyyppi_01(#[0-9]*)?/.test(t)
+            ) === -1
+        )
+        const orgs =
+          orgsWithoutKoulutustoimija.length > 0
+            ? orgsWithoutKoulutustoimija
+            : organisationsData.data
+        self.organisations = orgs.map((o: IOrganisation) => ({
           nimi: o.nimi,
-          oid: o.oid
+          oid: o.oid,
+          tyypit: o.tyypit
         }))
         if (self.user && self.organisations.length > 0) {
           if (self.organisations.findIndex(p => p.oid === storedOid) === -1) {

--- a/virkailija/src/stores/__tests__/SessionStore.test.ts
+++ b/virkailija/src/stores/__tests__/SessionStore.test.ts
@@ -1,4 +1,5 @@
 import { apiUrl } from "config"
+import { OrganisationModel } from "types/Organisation"
 import { createEnvironment } from "createEnvironment"
 import { mockFetch } from "fetchUtils"
 import { when } from "mobx"
@@ -96,6 +97,32 @@ describe("SessionStore", () => {
         store.changeSelectedOrganisationOid("1.1.111.111.11.11111111113")
         expect(store.hasWritePrivilege).not.toBeTruthy()
         expect(store.hasShallowDeletePrivilege).toBeTruthy()
+        expect(store.organisations.length).toEqual(2)
+        // the non-koulutustoimija orgs
+        done()
+      }
+    )
+  })
+
+  test("checkSession with only koulutustoimija orgs", done => {
+    const store = SessionStore.create(
+      {},
+      createEnvironment(mockFetch(apiUrl, 3), apiUrl, "", callerId)
+    )
+
+    store.checkSession()
+    expect(store.isLoading).toBe(true)
+
+    when(
+      () => !store.isLoading,
+      () => {
+        expect(store.organisations).toEqual([
+          OrganisationModel.create({
+            oid: "1.2.246.562.10.12424158690",
+            nimi: { fi: "Testiorganisaatio 2" },
+            tyypit: ["organisaatiotyyppi_02", "organisaatiotyyppi_01"]
+          })
+        ])
         done()
       }
     )

--- a/virkailija/src/stores/mocks/virkailija_external_organisaatio_find1.json
+++ b/virkailija/src/stores/mocks/virkailija_external_organisaatio_find1.json
@@ -1,0 +1,27 @@
+{
+  "meta": {},
+  "data": [
+    {
+      "oid": "1.2.246.562.10.12424158689",
+      "nimi": {
+	"fi": "Testiorganisaatio 1"
+      }
+    },
+    {
+      "oid": "1.2.246.562.10.12424158690",
+      "nimi": {
+	"fi": "Testiorganisaatio 2"
+      },
+      "tyypit": [
+	"organisaatiotyyppi_02",
+	"organisaatiotyyppi_01"
+      ]
+    },
+    {
+      "oid": "1.2.246.562.10.12944436166",
+      "nimi": {
+	"fi": "Ammatillinen opettajakorkeakoulu, Jyväskylä"
+      }
+    }
+  ]
+}

--- a/virkailija/src/stores/mocks/virkailija_external_organisaatio_find3.json
+++ b/virkailija/src/stores/mocks/virkailija_external_organisaatio_find3.json
@@ -1,0 +1,15 @@
+{
+  "meta": {},
+  "data": [
+    {
+      "oid": "1.2.246.562.10.12424158690",
+      "nimi": {
+	"fi": "Testiorganisaatio 2"
+      },
+      "tyypit": [
+	"organisaatiotyyppi_02",
+	"organisaatiotyyppi_01"
+      ]
+    }
+  ]
+}

--- a/virkailija/src/stores/mocks/virkailija_session3.json
+++ b/virkailija/src/stores/mocks/virkailija_session3.json
@@ -1,0 +1,27 @@
+{
+  "meta": {},
+  "data": {
+    "oidHenkilo": "1.1.111.111.11.11111111111",
+    "isSuperuser": false,
+    "organisation-privileges": [
+      {
+        "oid": "1.1.111.111.11.11111111112",
+        "privileges": ["read", "update", "delete", "write"],
+        "roles": [],
+        "child-organisations": ["1.1.111.111.11.11111111115"]
+      },
+      {
+        "oid": "1.1.111.111.11.11111111113",
+        "privileges": ["read"],
+        "roles": [],
+        "child-organisations": []
+      },
+      {
+        "oid": "1.1.111.111.11.11111111114",
+        "privileges": ["hoks_delete"],
+        "roles": [],
+        "child-organisations": ["1.1.111.111.11.11111111113"]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Kuvaus muutoksista

Koulutustoimijoilla ei ole koskaan omia HOKSeja, joten käyttäjillä joilla oppilaitoksen oikeudet on annettu koulutustoimijan kautta, koulutustoimijataso näkyy erikseen organisaatiovalikossa turhaan (koska sillä ei koskaan ole HOKSeja).  Varmuuden vuoksi tein kuitenkin niin, että jos filtteröinnin vuoksi organisaatiovalikko olisi tyhjä niin sitten näytetään koulutustoimijatkin (koska muuten organisaatiovalikosta ei pystyisi näkemään että on oikeuksia mihinkään).

https://jira.eduuni.fi/browse/EH-1996

## Muistilista PR:n tekijälle ja katselmoijille

### Ennen asettamista katselmointiin
  - [x] Build onnistuu ilman virheitä
  - [x] Toiminnallisuuden kattavat yksikkötestit on tehty osana PR:ia
  - [x] Toteutuksessa käytetyt komponentit on katsottu, voidaanko käyttää [ODS:n](https://github.com/Opetushallitus/oph-design-system) vastaavia
  - [x] Koodi on riittävästi dokumentoitu tai se on muuten yksiselitteistä
  - [x] Nimet (muuttujat, funktiot, ...) kuvaavat koodia hyvin

❗ **Katselmoijat tarkastavat, että yllä mainitut kohdat toteutuvat**

### Ennen mergeämistä `master`-haaralle
  - [x] Vähintään yksi kehittäjä on katselmoinut ja hyväksynyt muutokset
    - Jos muutoksilla voi jotain rikkoessaan olla kauaskantoiset vaikutukset, kannattaa muutokset hyväksyttää useammalla katselmoijalla
  - [x] Katselmoijien esittämät muutosehdotukset on huomioitu
  - [x] Muutokset on testattu QA-ympäristössä
    - [x] Testausohje kirjoitettu
    - [x] Testaus delegoitu OPH:lle mikäli mahdollista
  - [x] Yli jääneet kehityskohteet on tiketöity
